### PR TITLE
chore: update coral-sql to version 1.5.2

### DIFF
--- a/apps/example-query-module/package.json
+++ b/apps/example-query-module/package.json
@@ -19,7 +19,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "coral-sql": "^1.5.1",
+    "coral-sql": "^1.5.2",
     "tsx": "^4.20.5"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     "apps/example-query-module": {
       "version": "0.0.0",
       "dependencies": {
-        "coral-sql": "^1.5.1",
+        "coral-sql": "^1.5.2",
         "tsx": "^4.20.5"
       },
       "devDependencies": {
@@ -3606,6 +3606,18 @@
         "@clack/core": "^0.3.3",
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@csstools/postcss-cascade-layers": {
@@ -8588,9 +8600,9 @@
       }
     },
     "node_modules/coral-sql": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/coral-sql/-/coral-sql-1.5.1.tgz",
-      "integrity": "sha512-YJNmPbpgi0RsFo+8u7Va88zqwqceuzqVU39OfOsW260RojMAx4mESZmQIkGpJ1yC1ns/oAABjAGnOHTSj2gi+g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/coral-sql/-/coral-sql-1.5.2.tgz",
+      "integrity": "sha512-5fDRaEgCH1LN44RiSyLx4DzSLt6YHZcFtxeYWkfgXnHL6aKakcm8Bbs+t59qtsald1jHleLqX1eaYOPKF83qUQ==",
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
@@ -17569,7 +17581,7 @@
         "@rym-lib/query-module-sql-builder": "1.2.10",
         "@types/node": "^22.4.1",
         "@vitest/coverage-v8": "^3.0.3",
-        "coral-sql": "^1.5.1",
+        "coral-sql": "^1.5.2",
         "npm-check-updates": "^17.0.6",
         "prisma": "^5.22.0",
         "tsup": "^8.2.4",
@@ -17591,7 +17603,7 @@
         "@rym-lib/dev-config": "*",
         "@rym-lib/query-module": "1.2.10",
         "@types/node": "^22.4.1",
-        "coral-sql": "^1.5.1",
+        "coral-sql": "^1.5.2",
         "npm-check-updates": "^17.0.6",
         "sequelize": "^6.37.3",
         "tsup": "^8.2.4",
@@ -17953,7 +17965,7 @@
       "version": "1.2.10",
       "license": "MIT",
       "dependencies": {
-        "coral-sql": "^1.5.1"
+        "coral-sql": "^1.5.2"
       },
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -18225,7 +18237,7 @@
       "devDependencies": {
         "@rym-lib/dev-config": "*",
         "@types/node": "^22.4.1",
-        "coral-sql": "^1.5.1",
+        "coral-sql": "^1.5.2",
         "npm-check-updates": "^17.0.6",
         "tsup": "^8.2.4",
         "vitest": "^2.0.5"

--- a/packages/query-module-driver-prisma/package.json
+++ b/packages/query-module-driver-prisma/package.json
@@ -45,7 +45,7 @@
     "@rym-lib/query-module-sql-builder": "1.2.10",
     "@types/node": "^22.4.1",
     "@vitest/coverage-v8": "^3.0.3",
-    "coral-sql": "^1.5.1",
+    "coral-sql": "^1.5.2",
     "npm-check-updates": "^17.0.6",
     "prisma": "^5.22.0",
     "tsup": "^8.2.4",

--- a/packages/query-module-driver-sequelize/package.json
+++ b/packages/query-module-driver-sequelize/package.json
@@ -32,7 +32,7 @@
     "@rym-lib/dev-config": "*",
     "@rym-lib/query-module": "1.2.10",
     "@types/node": "^22.4.1",
-    "coral-sql": "^1.5.1",
+    "coral-sql": "^1.5.2",
     "npm-check-updates": "^17.0.6",
     "sequelize": "^6.37.3",
     "tsup": "^8.2.4",

--- a/packages/query-module-sql-builder/package.json
+++ b/packages/query-module-sql-builder/package.json
@@ -44,6 +44,6 @@
     "vitest": "^3.0.3"
   },
   "dependencies": {
-    "coral-sql": "^1.5.1"
+    "coral-sql": "^1.5.2"
   }
 }

--- a/packages/rdb-command/package.json
+++ b/packages/rdb-command/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@rym-lib/dev-config": "*",
     "@types/node": "^22.4.1",
-    "coral-sql": "^1.5.1",
+    "coral-sql": "^1.5.2",
     "npm-check-updates": "^17.0.6",
     "tsup": "^8.2.4",
     "vitest": "^2.0.5"


### PR DESCRIPTION
## Summary
• Update coral-sql dependency from 1.5.1 to 1.5.2 across all packages

## Test plan
- [ ] Run tests to ensure compatibility with the new coral-sql version
- [ ] Verify no breaking changes in the updated dependency

🤖 Generated with [Claude Code](https://claude.ai/code)