### PR TITLE
refactor: replace console logging with logger in TransactionManager

### DIFF
--- a/packages/rdb-command/src/database-nested-txn.spec.ts
+++ b/packages/rdb-command/src/database-nested-txn.spec.ts
@@ -8,6 +8,7 @@ class DummyDataBaseLogger implements DataBaseLogger {
   debug = vi.fn()
   info = vi.fn()
   warning = vi.fn()
+  warn = this.warning
   error = vi.fn()
   critical = vi.fn()
 }
@@ -73,9 +74,10 @@ describe('DataBase Nested Transaction Integration', () => {
   let db: DataBase
 
   beforeEach(() => {
-    transactionManager = new TransactionManager()
     connector = new MockConnector()
     logger = new DummyDataBaseLogger()
+    const context = { logger }
+    transactionManager = new TransactionManager(context)
     db = new DataBase(connector, logger, { transactionManager })
   })
 

--- a/packages/rdb-command/src/database-nested-txn.spec.ts
+++ b/packages/rdb-command/src/database-nested-txn.spec.ts
@@ -8,7 +8,7 @@ class DummyDataBaseLogger implements DataBaseLogger {
   debug = vi.fn()
   info = vi.fn()
   warning = vi.fn()
-  warn = this.warning
+  warn = vi.fn()
   error = vi.fn()
   critical = vi.fn()
 }

--- a/packages/rdb-command/src/database.ts
+++ b/packages/rdb-command/src/database.ts
@@ -50,7 +50,7 @@ export class DataBase implements DataBasePort {
     }
 
     // TransactionManagerが未指定の場合、新しいインスタンスを自動作成
-    this.transactionManager = transactionManager || new TransactionManager()
+    this.transactionManager = transactionManager || new TransactionManager(this.context)
   }
 
   async findOrCreate<Row>(

--- a/packages/rdb-command/src/interfaces.ts
+++ b/packages/rdb-command/src/interfaces.ts
@@ -10,6 +10,7 @@ export interface DataBaseLogger {
   debug(format: string, ...args: unknown[]): void
   info(format: string, ...args: unknown[]): void
   warning(format: string, ...args: unknown[]): void
+  warn(format: string, ...args: unknown[]): void
   error(format: string, ...args: unknown[]): void
   critical(format: string, ...args: unknown[]): void
 }

--- a/packages/rdb-command/src/transaction-manager.spec.ts
+++ b/packages/rdb-command/src/transaction-manager.spec.ts
@@ -20,7 +20,7 @@ class DummyDataBaseLogger implements DataBaseLogger {
   debug() {}
   info() {}
   warning() {}
-  warn = this.warning
+  warn() {}
   error() {}
   critical() {}
 }


### PR DESCRIPTION
## Summary
- Replace direct console logging calls with logger instance in TransactionManager
- Ensure consistent logging behavior across the rdb-command package
- Access logger from DataBase context to maintain existing logging configuration

## Changes
- `runInTransaction`: Replace `console.error` with `logger.error`
- `executeRoot`: Replace `console.debug` and `console.warn` with respective logger methods
- `executeNested`: Replace `console.debug`, `console.warn`, and `console.error` with logger methods
- Extract logger from DataBase context to maintain consistency

## Test plan
- [ ] Verify existing tests still pass
- [ ] Check that logging behavior is maintained through logger interface
- [ ] Confirm no breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)