### PR TITLE
refactor: unify logger warn method to warning in rdb-command

### DIFF
--- a/packages/rdb-command/src/database-nested-txn.spec.ts
+++ b/packages/rdb-command/src/database-nested-txn.spec.ts
@@ -8,7 +8,6 @@ class DummyDataBaseLogger implements DataBaseLogger {
   debug = vi.fn()
   info = vi.fn()
   warning = vi.fn()
-  warn = vi.fn()
   error = vi.fn()
   critical = vi.fn()
 }

--- a/packages/rdb-command/src/interfaces.ts
+++ b/packages/rdb-command/src/interfaces.ts
@@ -10,7 +10,6 @@ export interface DataBaseLogger {
   debug(format: string, ...args: unknown[]): void
   info(format: string, ...args: unknown[]): void
   warning(format: string, ...args: unknown[]): void
-  warn(format: string, ...args: unknown[]): void
   error(format: string, ...args: unknown[]): void
   critical(format: string, ...args: unknown[]): void
 }

--- a/packages/rdb-command/src/transaction-manager.spec.ts
+++ b/packages/rdb-command/src/transaction-manager.spec.ts
@@ -20,7 +20,6 @@ class DummyDataBaseLogger implements DataBaseLogger {
   debug() {}
   info() {}
   warning() {}
-  warn() {}
   error() {}
   critical() {}
 }
@@ -288,7 +287,7 @@ describe('TransactionManager', () => {
 
   describe('エラーハンドリング', () => {
     it('should handle transaction timeout warnings', async () => {
-      const loggerSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+      const loggerSpy = vi.spyOn(logger, 'warning').mockImplementation(() => {})
 
       await transactionManager.runInTransaction(
         db,

--- a/packages/rdb-command/src/transaction-manager.ts
+++ b/packages/rdb-command/src/transaction-manager.ts
@@ -214,7 +214,7 @@ export class TransactionManager {
 
         const duration = Date.now() - startTime
         if (duration > options.warningThreshold) {
-          this.context.logger.warn(`Long transaction detected: ${duration}ms`, {
+          this.context.logger.warning(`Long transaction detected: ${duration}ms`, {
             contextId: context.id,
             metadata: options.metadata,
           })
@@ -269,7 +269,7 @@ export class TransactionManager {
 
         const duration = Date.now() - startTime
         if (duration > options.warningThreshold) {
-          this.context.logger.warn(
+          this.context.logger.warning(
             `Long nested transaction detected: ${duration}ms`,
             {
               contextId: childContext.id,


### PR DESCRIPTION
## Summary
- DataBaseLoggerインターフェースからwarnメソッドを削除
- TransactionManagerでlogger.warn()をlogger.warning()に統一
- テストのモック実装からwarnメソッドを削除
- テストのスパイをwarnからwarningメソッドに修正

## 背景
2025-09-07に追加されたwarnメソッドとwarningメソッドが重複しており、APIの一貫性のためにwarningメソッドに統一します。

## Test plan
- [x] TypeScriptのビルドが成功することを確認
- [x] 全てのテスト(55件)が成功することを確認
- [x] logger.warning()が正しく呼び出されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)