### PR TITLE
feat: upgrade inversify from v6 to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3614,6 +3614,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@csstools/postcss-cascade-layers": {
       "version": "4.0.6",
       "dev": true,
@@ -4293,6 +4305,68 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inversifyjs/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-WlzR9xGadABS9gtgZQ+luoZ8V6qm4Ii6RQfcfC9Ho2SOlE6ZuemFo7PKJvKI0ikm8cmKbU8hw5UK6E4qovH21w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inversifyjs/container": {
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/container/-/container-1.14.5.tgz",
+      "integrity": "sha512-fbNiJc66HaY5QUbIDnONNhwusQQSv8xkf9y54WfuG9v2tqPG8wGLSwt1+cwUtRFHjs1RlQnA6eCd2HuLRZ9r0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/core": "9.1.2",
+        "@inversifyjs/plugin": "0.2.0",
+        "@inversifyjs/reflect-metadata-utils": "1.4.1"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
+      }
+    },
+    "node_modules/@inversifyjs/core": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/core/-/core-9.1.2.tgz",
+      "integrity": "sha512-8baIvwVUliZ6TeaYI0w8XRMTOX3i3AtANolbH/8TazecALIcpLAaiadKOm2yPguac1uCIUznSglOlG411rBTAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/prototype-utils": "0.1.3",
+        "@inversifyjs/reflect-metadata-utils": "1.4.1"
+      }
+    },
+    "node_modules/@inversifyjs/plugin": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/plugin/-/plugin-0.2.0.tgz",
+      "integrity": "sha512-R/JAdkTSD819pV1zi0HP54mWHyX+H2m8SxldXRgPQarS3ySV4KPyRdosWcfB8Se0JJZWZLHYiUNiS6JvMWSPjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inversifyjs/prototype-utils": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/prototype-utils/-/prototype-utils-0.1.3.tgz",
+      "integrity": "sha512-EzRamZzNgE9Sn3QtZ8NncNa2lpPMZfspqbK6BWFguWnOpK8ymp2TUuH46ruFHZhrHKnknPd7fG22ZV7iF517TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2"
+      }
+    },
+    "node_modules/@inversifyjs/reflect-metadata-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@inversifyjs/reflect-metadata-utils/-/reflect-metadata-utils-1.4.1.tgz",
+      "integrity": "sha512-Cp77C4d2wLaHXiUB7iH6Cxb7i1lD/YDuTIHLTDzKINqGSz0DCSoL/Dg2wVkW/6Qx03r/yQMLJ+32Agl32N2X8g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "reflect-metadata": "~0.2.2"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -10585,9 +10659,16 @@
       "license": "ISC"
     },
     "node_modules/inversify": {
-      "version": "6.0.2",
+      "version": "7.10.8",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-7.10.8.tgz",
+      "integrity": "sha512-NF9t4p1j5BtrJjf1jXRlGCXvixjtdu5UFkmye/3zFrITJbB7KvrkNS1vm8yAm8RW07hst4yxpvXGG3JtrQ365w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@inversifyjs/common": "1.5.2",
+        "@inversifyjs/container": "1.14.5",
+        "@inversifyjs/core": "9.1.2"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -16185,13 +16266,13 @@
       "devDependencies": {
         "@rym-lib/dev-config": "*",
         "@types/node": "^22.4.1",
-        "inversify": "^6.0.2",
+        "inversify": "^7.0.0",
         "npm-check-updates": "^17.0.6",
         "tsup": "^8.2.4",
         "vitest": "^2.0.5"
       },
       "peerDependencies": {
-        "inversify": "^6.0"
+        "inversify": "^7.0.0"
       }
     },
     "packages/inversify-bundler-express": {

--- a/packages/inversify-bundler-express/src/express.ts
+++ b/packages/inversify-bundler-express/src/express.ts
@@ -24,7 +24,7 @@ export const container = (
     )
 
     const container = new Container()
-    container.load(...bundler.resolve())
+    container.loadSync(...bundler.resolve())
 
     req.container = container
 

--- a/packages/inversify-bundler/package.json
+++ b/packages/inversify-bundler/package.json
@@ -38,12 +38,12 @@
   "devDependencies": {
     "@rym-lib/dev-config": "*",
     "@types/node": "^22.4.1",
-    "inversify": "^6.0.2",
+    "inversify": "^7.0.0",
     "npm-check-updates": "^17.0.6",
     "tsup": "^8.2.4",
     "vitest": "^2.0.5"
   },
   "peerDependencies": {
-    "inversify": "^6.0"
+    "inversify": "^7.0.0"
   }
 }

--- a/packages/inversify-bundler/src/bundler.ts
+++ b/packages/inversify-bundler/src/bundler.ts
@@ -1,7 +1,7 @@
-import { ContainerModule, ContainerModuleInterface } from './container-module'
+import { ContainerModule } from './container-module'
 
 interface BundlerPort {
-  resolve(): ContainerModuleInterface[]
+  resolve(): ContainerModule[]
 }
 
 type ModuleInput = ContainerModule | BundlerPort
@@ -13,7 +13,7 @@ class Bundler implements BundlerPort {
     this.inputs = inputs
   }
 
-  resolve(): ContainerModuleInterface[] {
+  resolve(): ContainerModule[] {
     const exists = new Map<string, boolean>()
     const modules = this.inputs
       .map((module) => {

--- a/packages/inversify-bundler/src/container-module.ts
+++ b/packages/inversify-bundler/src/container-module.ts
@@ -1,11 +1,17 @@
 import {
-  interfaces,
   ContainerModule as InversifyContainerModule,
+  ContainerModuleLoadOptions,
 } from 'inversify'
 
-interface ContainerModuleInterface extends interfaces.ContainerModule {
+interface ContainerModuleInterface {
   name: string
+  id: number
+  load(options: ContainerModuleLoadOptions): void | Promise<void>
 }
+
+type ContainerModuleCallback = (
+  options: ContainerModuleLoadOptions,
+) => void | Promise<void>
 
 type ContainerModuleOptions = {
   name: string
@@ -15,17 +21,20 @@ class ContainerModule
   extends InversifyContainerModule
   implements ContainerModuleInterface
 {
+  private _name: string | undefined
+
   constructor(
-    registry: interfaces.ContainerModuleCallBack,
+    load: ContainerModuleCallback,
     private options: Partial<ContainerModuleOptions> = {},
   ) {
-    super(registry)
+    super(load)
+    this._name = options.name
   }
 
   get name() {
-    return this.options.name ?? this.registry.toString()
+    return this._name ?? `module-${this.id}`
   }
 }
 
 export { ContainerModule }
-export type { ContainerModuleInterface }
+export type { ContainerModuleInterface, ContainerModuleCallback }

--- a/packages/inversify-bundler/src/create-module.ts
+++ b/packages/inversify-bundler/src/create-module.ts
@@ -1,19 +1,19 @@
-import { interfaces } from 'inversify'
+import { Newable, ResolutionContext } from 'inversify'
 
 import { Bundler, ModuleInput } from './bundler'
 import { ContainerModule } from './container-module'
 
 class ModuleBuilder<T> {
-  constructor(public build: (context: interfaces.Context) => T) {}
+  constructor(public build: (context: ResolutionContext) => T) {}
 }
 
-export function builder<T>(fn: (context: interfaces.Context) => T) {
+export function builder<T>(fn: (context: ResolutionContext) => T) {
   return new ModuleBuilder<T>(fn)
 }
 
 export function createModule<Port, Context = {}>(
   name: string,
-  Module: interfaces.Newable<Port> | ModuleBuilder<Port>,
+  Module: Newable<Port> | ModuleBuilder<Port>,
   modules: ModuleInput[] = [],
   options: { singleton?: boolean } = {},
 ) {
@@ -21,7 +21,7 @@ export function createModule<Port, Context = {}>(
   const bundler = new Bundler(
     ...modules,
     new ContainerModule(
-      (bind) => {
+      ({ bind }) => {
         const bindingTo = bind<Port>(identifier)
         const binding =
           Module instanceof ModuleBuilder

--- a/packages/inversify-bundler/src/index.ts
+++ b/packages/inversify-bundler/src/index.ts
@@ -1,12 +1,23 @@
-import { Container, inject, injectable, interfaces } from 'inversify'
+import {
+  Container,
+  inject,
+  injectable,
+  ServiceIdentifier,
+  Newable,
+  ResolutionContext,
+  ContainerModuleLoadOptions,
+  ContainerOptions,
+} from 'inversify'
 
 import { Bundler, ModuleInput } from './bundler'
-import { ContainerModule, ContainerModuleInterface } from './container-module'
+import {
+  ContainerModule,
+  ContainerModuleInterface,
+  ContainerModuleCallback,
+} from './container-module'
 import { builder, createModule } from './create-module'
 
-type ServiceIdentifier<T> = interfaces.ServiceIdentifier<T>
-type Newable<T> = interfaces.Newable<T>
-type ContainerInterface = interfaces.Container
+type ContainerInterface = Container
 
 export {
   builder,
@@ -19,10 +30,13 @@ export {
 }
 
 export type {
-  interfaces,
   ContainerInterface,
+  ContainerModuleCallback,
   ContainerModuleInterface,
+  ContainerModuleLoadOptions,
+  ContainerOptions,
   ModuleInput,
   Newable,
+  ResolutionContext,
   ServiceIdentifier,
 }

--- a/packages/nakadachi-interactor/src/interactor.ts
+++ b/packages/nakadachi-interactor/src/interactor.ts
@@ -1,5 +1,6 @@
 import {
   Bundler,
+  Container,
   ContainerInterface,
   ContainerModule,
   ModuleInput,
@@ -89,7 +90,7 @@ export class App<
       const router = dispatch(new Router())
       const bundler = new Bundler(
         ...router.modules,
-        new ContainerModule((bind) => {
+        new ContainerModule(({ bind }) => {
           for (const Interactor of router.interactor) {
             bind(Interactor).toSelf()
           }
@@ -170,7 +171,7 @@ export class App<
     const identifier = Symbol.for(name)
     const bundler = new Bundler(
       ...modules,
-      new ContainerModule((bind) => {
+      new ContainerModule(({ bind }) => {
         bind<InteractionPort<Data>>(identifier).to(Interactor)
       }),
     )
@@ -181,8 +182,8 @@ export class App<
   }
 
   private createContainer(parent: ContainerInterface, bundler: Bundler) {
-    const container = parent.createChild()
-    container.load(...bundler.resolve())
+    const container = new Container({ parent })
+    container.loadSync(...bundler.resolve())
     return container
   }
 }


### PR DESCRIPTION
## Summary
- Inversify v7へのアップグレード対応
- 破壊的変更に対応したコードの修正

### 変更点
- `ContainerModule`のコールバック引数を `(bind)` から `({ bind })` に変更
- `interfaces.Context` を `ResolutionContext` に変更
- `interfaces.Newable` を `Newable` に変更
- `interfaces.ServiceIdentifier` を `ServiceIdentifier` に変更
- `container.load()` を `container.loadSync()` に変更
- `parent.createChild()` を `new Container({ parent })` に変更

### 影響パッケージ
- `@rym-lib/inversify-bundler` - inversify v7 へ peerDependency を更新
- `@rym-lib/inversify-bundler-express` - loadSync への変更
- `@rym-lib/nakadachi-interactor` - Container APIの変更に対応

## Test plan
- [x] 全パッケージのビルドが成功することを確認
- [x] 全パッケージのテストがパスすることを確認

## References
- [Migrating from v6 | InversifyJS](https://inversify.io/docs/guides/migrating-from-v6/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


このPRは InversifyJS を v6 から v7 にアップグレードし、すべての破壊的変更に適切に対応しています。

## 主な変更点
- **ContainerModule API**: コールバック引数を `(bind)` から `({ bind })` に変更
- **型のインポート**: `interfaces.Context` → `ResolutionContext`、`interfaces.Newable` → `Newable`、`interfaces.ServiceIdentifier` → `ServiceIdentifier`
- **Container API**: `container.load()` → `container.loadSync()`、`parent.createChild()` → `new Container({ parent })`
- **peerDependencies**: `inversify` を `^7.0.0` に更新

## 影響範囲
- `@rym-lib/inversify-bundler`: コアモジュールの API 更新
- `@rym-lib/inversify-bundler-express`: `loadSync` への対応
- `@rym-lib/nakadachi-interactor`: Container API の変更に対応

すべての変更は [inversify v7 migration guide](https://inversify.io/docs/guides/migrating-from-v6/) に沿って正しく実装されており、テストも通過しているとのことです。

<h3>Confidence Score: 5/5</h3>


- このPRは安全にマージできます。
- すべての inversify v7 の破壊的変更に適切に対応しており、API の変更は一貫性があり、公式マイグレーションガイドに準拠しています。テストも全て通過しているため、ランタイムエラーのリスクはありません。reflect-metadata については inversify v7 自体が @inversifyjs/container 経由で peerDependency として定義しているため問題ありません。
- 注意が必要なファイルはありません。すべての変更は適切に実装されています。

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/inversify-bundler/src/container-module.ts | ContainerModuleCallback のシグネチャを v7 API に更新。interfaces から ContainerModuleLoadOptions へ変更。name プロパティを private フィールド _name に変更し、デフォルトで module-${this.id} を使用。 |
| packages/inversify-bundler/src/create-module.ts | interfaces.Context を ResolutionContext に、interfaces.Newable を Newable に更新。ContainerModule コールバックを (bind) => から ({ bind }) => に変更。 |
| packages/inversify-bundler/src/index.ts | interfaces 名前空間の使用を削除し、inversify から直接型をインポート。ServiceIdentifier、Newable、ResolutionContext などを個別にエクスポート。 |
| packages/inversify-bundler-express/src/express.ts | container.load() を container.loadSync() に変更。これは inversify v7 の破壊的変更に対応。 |
| packages/nakadachi-interactor/src/interactor.ts | ContainerModule コールバックを ({ bind }) => に更新、parent.createChild() を new Container({ parent }) に、container.load() を container.loadSync() に変更。すべて inversify v7 の API 変更に適合。 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as アプリケーション
    participant CM as ContainerModule
    participant Bundler as Bundler
    participant Container as Container (v7)
    
    Note over CM: v7: コールバック ({ bind }) に変更
    App->>CM: new ContainerModule(({ bind }) => {...})
    
    Note over Bundler: モジュールを収集・重複排除
    App->>Bundler: new Bundler(...modules)
    Bundler->>Bundler: resolve()
    Bundler-->>App: ContainerModule[]
    
    Note over Container: v7: new Container({ parent })
    App->>Container: new Container({ parent })
    
    Note over Container: v7: loadSync() に変更
    App->>Container: container.loadSync(...modules)
    Container->>CM: load({ bind, ... })
    CM->>Container: bind<T>(id).to(Class)
    
    Note over Container: 依存性解決
    App->>Container: container.get<T>(identifier)
    Container-->>App: インスタンス
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->