### PR TITLE
feat(seeder): add no_update option to skip updating existing records

### DIFF
--- a/packages/seeder/src/seeder.ts
+++ b/packages/seeder/src/seeder.ts
@@ -2,15 +2,18 @@ import { PrismaClient } from '@prisma/client'
 
 type Value = string | number | Date | boolean
 
+export type SeederOptions = {
+  created_at?: boolean
+  updated_at?: boolean
+  quote?: '`' | '"' | ''
+  placeholder?: '$' | '?'
+  no_update?: boolean
+}
+
 export class Seeder {
   constructor(
     private client: PrismaClient,
-    private options: {
-      created_at?: boolean
-      updated_at?: boolean
-      quote?: '`' | '"' | ''
-      placeholder?: '$' | '?'
-    },
+    private options: SeederOptions,
   ) {}
 
   async load(
@@ -18,7 +21,9 @@ export class Seeder {
     pk: string,
     columns: string[],
     records: Value[][],
+    options?: Partial<SeederOptions>,
   ): Promise<void> {
+    const merged_options = { ...this.options, ...options }
     for (const record of records) {
       const pk_index = columns.findIndex((prop) => prop === pk)
       if (pk_index < 0)
@@ -37,6 +42,10 @@ export class Seeder {
       const row = queryResult[0] as Record<string, any> | undefined
 
       if (row) {
+        if (merged_options.no_update) {
+          // no_updateオプションが指定されている場合はスキップ
+          continue
+        }
         if (
           !columns.filter((prop, index) => row[prop] !== record[index]).length
         ) {
@@ -53,7 +62,7 @@ export class Seeder {
         const values = columns
           .map((_, index) => (index === pk_index ? null : record[index]))
           .filter((value) => value !== null)
-        if (this.options.updated_at) {
+        if (merged_options.updated_at) {
           setters.push(
             `${this.escape('updated_at')} = ${this.getPlaceholder(index++)}`,
           )
@@ -71,11 +80,11 @@ export class Seeder {
       } else {
         const cols = [...columns].map((col) => `${this.escape(col)}`)
         const values = columns.map((_, index) => record[index])
-        if (this.options.created_at) {
+        if (merged_options.created_at) {
           cols.push(this.escape('created_at'))
           values.push(new Date())
         }
-        if (this.options.updated_at) {
+        if (merged_options.updated_at) {
           cols.push(this.escape('updated_at'))
           values.push(new Date())
         }


### PR DESCRIPTION
## Summary
- Add `no_update` option to `SeederOptions` to skip UPDATE operations for existing records
- Allow per-call option overrides via optional 5th parameter in `load()` method
- Export `SeederOptions` type for external use

## Test plan
- [ ] Verify existing records are preserved when `no_update: true` is passed
- [ ] Verify new records are still inserted when `no_update: true`
- [ ] Verify default behavior (update existing records) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


`SeederOptions`型をエクスポートし、既存レコードの更新をスキップする`no_update`オプションを追加しました。`load()`メソッドに5番目のオプション引数を追加することで、呼び出し時にオプションを上書きできるようになりました。

主な変更点:
- `SeederOptions`型を外部利用可能にエクスポート
- `no_update?: boolean`を`SeederOptions`に追加
- `load()`メソッドに`options?: Partial<SeederOptions>`パラメータを追加
- インスタンスオプションと呼び出し時オプションをマージする仕組みを実装
- 既存レコードが見つかった場合、`no_update`が`true`であればUPDATEをスキップ
- `this.options`の参照をすべて`merged_options`に変更し、オプションマージの一貫性を確保

<h3>Confidence Score: 5/5</h3>


- このPRは安全にマージできます。シンプルで明確な機能追加であり、既存の動作に影響を与えません
- 実装は論理的に正しく、後方互換性を保ちながら新機能を追加しています。オプションのマージ処理が適切に実装され、既存のINSERT処理には影響を与えず、UPDATE処理も期待通りにスキップされます。型安全性も維持されています
- 特に注意が必要なファイルはありません

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/seeder/src/seeder.ts | `SeederOptions`型のエクスポート、`no_update`オプションの追加、`load()`メソッドへのオプション引数追加により既存レコードの更新をスキップできるように実装 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Seeder
    participant PrismaClient
    participant Database

    Client->>Seeder: load(table_name, pk, columns, records, options?)
    Seeder->>Seeder: merge options (this.options + options)
    
    loop for each record
        Seeder->>Seeder: find pk_index in columns
        Seeder->>PrismaClient: $queryRawUnsafe(SELECT by pk)
        PrismaClient->>Database: SELECT query
        Database-->>PrismaClient: query result
        PrismaClient-->>Seeder: row or undefined
        
        alt row exists (UPDATE path)
            alt merged_options.no_update is true
                Note over Seeder: Skip update (continue)
            else no changes detected
                Note over Seeder: Skip update (continue)
            else update needed
                Seeder->>Seeder: build UPDATE SQL with setters
                Seeder->>PrismaClient: $executeRawUnsafe(UPDATE)
                PrismaClient->>Database: UPDATE query
                Database-->>PrismaClient: success
                PrismaClient-->>Seeder: success
            end
        else row not exists (INSERT path)
            Seeder->>Seeder: build INSERT SQL
            Seeder->>PrismaClient: $executeRawUnsafe(INSERT)
            PrismaClient->>Database: INSERT query
            Database-->>PrismaClient: success
            PrismaClient-->>Seeder: success
        end
    end
    
    Seeder->>Seeder: log completion
    Seeder-->>Client: void
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->