### PR TITLE
feat(query-module): add count() with type-conditional exposure

### DIFF
--- a/packages/query-module-driver-prisma/src/driver.spec.ts
+++ b/packages/query-module-driver-prisma/src/driver.spec.ts
@@ -574,7 +574,7 @@ async function expectQuery<
 }
 
 describe('query-module-driver-prisma .executeCount', () => {
-  let driver: QueryDriverInterface
+  let driver: QueryDriverPrisma
   beforeEach(() => {
     driver = new QueryDriverPrisma(prisma, {
       logger: createLogger(),
@@ -608,9 +608,7 @@ describe('query-module-driver-prisma .executeCount', () => {
   })
 
   it('should convert BigInt count to number', async () => {
-    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([
-      { count: 42n },
-    ] as any)
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([{ count: 42n }] as any)
 
     const count = await driver.executeCount(new QueryCriteria({}, {}))
 
@@ -619,9 +617,7 @@ describe('query-module-driver-prisma .executeCount', () => {
   })
 
   it('should fall back to first column when count column missing', async () => {
-    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([
-      { 'COUNT(*)': 3 },
-    ] as any)
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([{ 'COUNT(*)': 3 }] as any)
 
     const count = await driver.executeCount(new QueryCriteria({}, {}))
 

--- a/packages/query-module-driver-prisma/src/driver.spec.ts
+++ b/packages/query-module-driver-prisma/src/driver.spec.ts
@@ -572,3 +572,80 @@ async function expectQuery<
     expected,
   )
 }
+
+describe('query-module-driver-prisma .executeCount', () => {
+  let driver: QueryDriverInterface
+  beforeEach(() => {
+    driver = new QueryDriverPrisma(prisma, {
+      logger: createLogger(),
+    })
+    driver.source((builder) => builder.from('example'))
+  })
+
+  it('should throw when source is not configured', async () => {
+    const fresh = new QueryDriverPrisma(prisma, { logger: createLogger() })
+    await expect(
+      fresh.executeCount(new QueryCriteria({}, {})),
+    ).rejects.toThrowError(/QueryDriver must be required source\./)
+  })
+
+  it('should issue SELECT COUNT(*) SQL', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([{ count: 5 }] as any)
+
+    await driver.executeCount(new QueryCriteria({}, {}))
+
+    expect(prismaMock.$queryRawUnsafe.mock.lastCall![0]).toBe(
+      'SELECT COUNT(*) AS `count`\nFROM\n  `example`',
+    )
+  })
+
+  it('should return numeric count from row.count', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([{ count: 7 }] as any)
+
+    const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+    expect(count).toBe(7)
+  })
+
+  it('should convert BigInt count to number', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([
+      { count: 42n },
+    ] as any)
+
+    const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+    expect(count).toBe(42)
+    expect(typeof count).toBe('number')
+  })
+
+  it('should fall back to first column when count column missing', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([
+      { 'COUNT(*)': 3 },
+    ] as any)
+
+    const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+    expect(count).toBe(3)
+  })
+
+  it('should return 0 when no rows', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([] as any)
+
+    const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+    expect(count).toBe(0)
+  })
+
+  it('should include WHERE filter in COUNT SQL', async () => {
+    prismaMock.$queryRawUnsafe.mockResolvedValueOnce([{ count: 1 }] as any)
+
+    await driver.executeCount(
+      new QueryCriteria({}, { filter: { value: { eq: 'foo' } } }),
+    )
+
+    const lastCall = prismaMock.$queryRawUnsafe.mock.lastCall!
+    expect(lastCall[0]).toContain('SELECT COUNT(*) AS `count`')
+    expect(lastCall[0]).toContain('WHERE')
+    expect(lastCall.slice(1)).toStrictEqual(['foo'])
+  })
+})

--- a/packages/query-module-driver-prisma/src/driver.ts
+++ b/packages/query-module-driver-prisma/src/driver.ts
@@ -4,6 +4,7 @@ import {
   QueryLoggerInterface,
 } from '@rym-lib/query-module'
 import {
+  buildCountSQL,
   buildSQL,
   createBuilder,
   CustomFilterFunction,
@@ -56,6 +57,31 @@ export class QueryDriverPrisma implements QueryDriverInterface {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return rows as Record<string, any>[]
+  }
+
+  async executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number> {
+    if (!this.setup) {
+      throw new Error('QueryDriver must be required source.')
+    }
+
+    const [sql, replacements] = buildCountSQL(
+      this.setup(this.builderSetup()),
+      criteria,
+      {
+        builder: this.builderSetup(),
+        customFilter: this.customFilter,
+      },
+    )
+    this.context.logger.verbose(`[QueryDriverPrisma] ${sql}`, { replacements })
+
+    const rows = (await this.db.$queryRawUnsafe(
+      sql,
+      ...replacements,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    )) as Record<string, any>[]
+    const first = rows[0] ?? {}
+    const value = first.count ?? Object.values(first)[0]
+    return Number(value ?? 0)
   }
 
   customFilter: CustomFilterFunction = (content, context, fn) => {

--- a/packages/query-module-driver-prisma/src/driver.ts
+++ b/packages/query-module-driver-prisma/src/driver.ts
@@ -77,8 +77,7 @@ export class QueryDriverPrisma implements QueryDriverInterface {
     const rows = (await this.db.$queryRawUnsafe(
       sql,
       ...replacements,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    )) as Record<string, any>[]
+    )) as Record<string, unknown>[]
     const first = rows[0] ?? {}
     const value = first.count ?? Object.values(first)[0]
     return Number(value ?? 0)

--- a/packages/query-module-driver-sequelize/src/driver.spec.ts
+++ b/packages/query-module-driver-sequelize/src/driver.spec.ts
@@ -165,4 +165,76 @@ describe('query-module-driver-sequelize', () => {
       })
     })
   })
+
+  describe('.executeCount', () => {
+    it('should throw when source is not configured', async () => {
+      const fresh = new QueryDriverSequelize(sequelize, {
+        logger: createLogger(),
+      })
+      await expect(
+        fresh.executeCount(new QueryCriteria({}, {})),
+      ).rejects.toThrowError(/QueryDriver must be required source\./)
+    })
+
+    it('should issue SELECT COUNT(*) SQL', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([{ count: 5 }])
+
+      await driver.executeCount(new QueryCriteria({}, {}))
+
+      const lastCall = mockQuery.mock.lastCall
+      expect(lastCall?.[0]).toBe('SELECT COUNT(*) AS `count`\nFROM\n  `example`')
+    })
+
+    it('should return numeric count from row.count', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([{ count: 7 }])
+
+      const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+      expect(count).toBe(7)
+    })
+
+    it('should convert string count to number', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([{ count: '42' }])
+
+      const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+      expect(count).toBe(42)
+      expect(typeof count).toBe('number')
+    })
+
+    it('should fall back to first column when count column missing', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([{ 'COUNT(*)': 3 }])
+
+      const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+      expect(count).toBe(3)
+    })
+
+    it('should return 0 when no rows', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([])
+
+      const count = await driver.executeCount(new QueryCriteria({}, {}))
+
+      expect(count).toBe(0)
+    })
+
+    it('should include WHERE filter in COUNT SQL', async () => {
+      driver.source((builder) => builder.from('example'))
+      mockQuery.mockResolvedValue([{ count: 1 }])
+
+      await driver.executeCount(
+        new QueryCriteria({}, { filter: { value: { eq: 'foo' } } }),
+      )
+
+      const lastCall = mockQuery.mock.lastCall
+      expect(lastCall?.[0]).toContain('SELECT COUNT(*) AS `count`')
+      expect(lastCall?.[0]).toContain('WHERE')
+      expect(lastCall?.[1].replacements).toStrictEqual(['foo'])
+    })
+  })
 })

--- a/packages/query-module-driver-sequelize/src/driver.spec.ts
+++ b/packages/query-module-driver-sequelize/src/driver.spec.ts
@@ -183,7 +183,9 @@ describe('query-module-driver-sequelize', () => {
       await driver.executeCount(new QueryCriteria({}, {}))
 
       const lastCall = mockQuery.mock.lastCall
-      expect(lastCall?.[0]).toBe('SELECT COUNT(*) AS `count`\nFROM\n  `example`')
+      expect(lastCall?.[0]).toBe(
+        'SELECT COUNT(*) AS `count`\nFROM\n  `example`',
+      )
     })
 
     it('should return numeric count from row.count', async () => {

--- a/packages/query-module-driver-sequelize/src/driver.ts
+++ b/packages/query-module-driver-sequelize/src/driver.ts
@@ -6,6 +6,7 @@ import {
   QueryLoggerInterface,
 } from '@rym-lib/query-module'
 import {
+  buildCountSQL,
   buildSQL,
   createBuilder,
   CustomFilterFunction,
@@ -57,6 +58,33 @@ export class QueryDriverSequelize implements QueryDriverInterface {
       type: QueryTypes.SELECT,
     })
     return rows as Record<string, any>[]
+  }
+
+  async executeCount(criteria: QueryCriteriaInterface): Promise<number> {
+    if (!this.setup) {
+      throw new Error('QueryDriver must be required source.')
+    }
+
+    const [sql, replacements] = buildCountSQL(
+      this.setup(this.builderSetup()),
+      criteria,
+      {
+        builder: this.builderSetup(),
+        customFilter: this.customFilter,
+      },
+    )
+    this.context.logger.verbose(`[QueryDriverSequelize] ${sql}`, {
+      sql,
+      replacements,
+    })
+
+    const rows = (await this.db.query(sql, {
+      replacements,
+      type: QueryTypes.SELECT,
+    })) as Record<string, any>[]
+    const first = rows[0] ?? {}
+    const value = first.count ?? Object.values(first)[0]
+    return Number(value ?? 0)
   }
 
   customFilter: CustomFilterFunction = (content, context, fn) => {

--- a/packages/query-module-driver-sequelize/src/driver.ts
+++ b/packages/query-module-driver-sequelize/src/driver.ts
@@ -81,7 +81,7 @@ export class QueryDriverSequelize implements QueryDriverInterface {
     const rows = (await this.db.query(sql, {
       replacements,
       type: QueryTypes.SELECT,
-    })) as Record<string, any>[]
+    })) as Record<string, unknown>[]
     const first = rows[0] ?? {}
     const value = first.count ?? Object.values(first)[0]
     return Number(value ?? 0)

--- a/packages/query-module-sql-builder/src/index.ts
+++ b/packages/query-module-sql-builder/src/index.ts
@@ -1,2 +1,6 @@
 export * from 'coral-sql'
-export { type CustomFilterFunction, buildSQL } from './sql-builder'
+export {
+  type CustomFilterFunction,
+  buildSQL,
+  buildCountSQL,
+} from './sql-builder'

--- a/packages/query-module-sql-builder/src/sql-builder.spec.ts
+++ b/packages/query-module-sql-builder/src/sql-builder.spec.ts
@@ -778,5 +778,13 @@ describe('query-module-sql-builder', () => {
       expect(sql).not.toContain('OFFSET')
       expect(sql).toBe('SELECT COUNT(*) AS `count` FROM `example`')
     })
+
+    it('should ignore having: prefixed filters to avoid HAVING clause without GROUP BY', () => {
+      const { sql } = executeCount(builder, {
+        filter: { 'having:amount': { gt: 100 } },
+      })
+      expect(sql).not.toContain('HAVING')
+      expect(sql).toBe('SELECT COUNT(*) AS `count` FROM `example`')
+    })
   })
 })

--- a/packages/query-module-sql-builder/src/sql-builder.spec.ts
+++ b/packages/query-module-sql-builder/src/sql-builder.spec.ts
@@ -1,4 +1,4 @@
-import { buildSQL } from './'
+import { buildCountSQL, buildSQL } from './'
 
 import { createBuilder, SQLBuilderPort } from 'coral-sql'
 import { beforeEach, describe, expect, it } from 'vitest'
@@ -733,6 +733,50 @@ describe('query-module-sql-builder', () => {
           }
         })
       })
+    })
+  })
+
+  describe('buildCountSQL', () => {
+    function executeCount(
+      builder: SQLBuilderPort,
+      criteria: Partial<TestCriteria>,
+    ) {
+      const [sql, bindings] = buildCountSQL(builder, createCriteria(criteria))
+      return { sql: xbr(sql), bindings }
+    }
+
+    it('should produce SELECT COUNT(*) without filter', () => {
+      const { sql, bindings } = executeCount(builder, {})
+      expect(sql).toBe('SELECT COUNT(*) AS `count` FROM `example`')
+      expect(bindings).toStrictEqual([])
+    })
+
+    it('should include WHERE filter conditions', () => {
+      const { sql, bindings } = executeCount(builder, {
+        filter: { name: { eq: 'alice' } },
+      })
+      expect(sql).toBe(
+        'SELECT COUNT(*) AS `count` FROM `example` WHERE (((`name` = ?)))',
+      )
+      expect(bindings).toStrictEqual(['alice'])
+    })
+
+    it('should ignore orderBy', () => {
+      const { sql } = executeCount(builder, {
+        orderBy: 'name:desc',
+      })
+      expect(sql).not.toContain('ORDER BY')
+      expect(sql).toBe('SELECT COUNT(*) AS `count` FROM `example`')
+    })
+
+    it('should ignore take/skip', () => {
+      const { sql } = executeCount(builder, {
+        take: 10,
+        skip: 5,
+      })
+      expect(sql).not.toContain('LIMIT')
+      expect(sql).not.toContain('OFFSET')
+      expect(sql).toBe('SELECT COUNT(*) AS `count` FROM `example`')
     })
   })
 })

--- a/packages/query-module-sql-builder/src/sql-builder.ts
+++ b/packages/query-module-sql-builder/src/sql-builder.ts
@@ -62,6 +62,7 @@ function applyFilters(
   builder: SQLBuilderPort,
   criteria: QueryCriteriaInterface,
   o: BuildSqlOptions,
+  flags: { skipHaving?: boolean } = {},
 ) {
   if (!criteria.filter) return
 
@@ -101,6 +102,10 @@ function applyFilters(
     }
   }
   builder.where(whole)
+
+  // NOTE: count クエリでは GROUP BY が無いので HAVING を出すと SQL エラーになる。
+  // 呼び出し側で skipHaving: true を渡すことで HAVING の組み立てを抑制する。
+  if (flags.skipHaving) return
 
   const whole_having = createConditions()
   for (const filter of Array.isArray(criteria.filter)
@@ -181,7 +186,7 @@ export function buildCountSQL<Driver extends QueryDriverInterface>(
   // 組み立てられた column(...) 群を捨てて COUNT(*) クエリに差し替える。
   // 結果セットのエイリアスは `count` 固定で、ドライバ側は row.count として参照する。
   builder.select('SELECT COUNT(*) AS `count`')
-  applyFilters(builder, criteria, o)
+  applyFilters(builder, criteria, o, { skipHaving: true })
   return builder.toSQL()
 }
 

--- a/packages/query-module-sql-builder/src/sql-builder.ts
+++ b/packages/query-module-sql-builder/src/sql-builder.ts
@@ -58,96 +58,97 @@ const defaults: BuildSqlOptions = {
   containsSplitSpaces: true,
 }
 
+function applyFilters(
+  builder: SQLBuilderPort,
+  criteria: QueryCriteriaInterface,
+  o: BuildSqlOptions,
+) {
+  if (!criteria.filter) return
+
+  const whole = createConditions()
+  for (const filter of Array.isArray(criteria.filter)
+    ? criteria.filter
+    : [criteria.filter]) {
+    if (!filter) continue
+
+    const cond = createConditions()
+    let hasCondition = false
+
+    for (const name of keys(filter)) {
+      if (typeof name !== 'string') continue
+      if (/^having:/.test(name)) continue
+
+      const property = filter[name]
+      if (!property) continue
+
+      const { value, filter: customFilter } = property as FilterPayload
+      hasCondition = true
+
+      const columnName = (() => {
+        if (!property) return name
+        if (typeof property !== 'object') return name
+        if (!('column' in property)) return name
+        if (!property.column) return name
+        if (typeof property.column === 'string') return property.column
+        return property.column() as SQLBuilderPort
+      })()
+
+      createCond(cond, columnName, { value, filter: customFilter }, o)
+    }
+
+    if (hasCondition) {
+      whole.or(cond)
+    }
+  }
+  builder.where(whole)
+
+  const whole_having = createConditions()
+  for (const filter of Array.isArray(criteria.filter)
+    ? criteria.filter
+    : [criteria.filter]) {
+    if (!filter) continue
+
+    const cond = createConditions()
+    let hasHavingCondition = false
+
+    for (const having_name of keys(filter)) {
+      if (typeof having_name !== 'string') continue
+      if (!/^having:/.test(having_name)) continue
+
+      const property = filter[having_name]
+      if (!property) continue
+
+      const { value, filter: customFilter } = property as FilterPayload
+      const name = having_name.replace(/^having:/, '')
+      hasHavingCondition = true
+
+      const columnName = (() => {
+        if (!property) return name
+        if (typeof property !== 'object') return name
+        if (!('column' in property)) return name
+        if (!property.column) return name
+        if (typeof property.column === 'string') return property.column
+        return property.column() as SQLBuilderPort
+      })()
+
+      createCond(cond, columnName, { value, filter: customFilter }, o)
+    }
+
+    if (hasHavingCondition) {
+      whole_having.or(cond)
+    }
+  }
+  builder.having(whole_having)
+}
+
 export function buildSQL<Driver extends QueryDriverInterface>(
   builder: SQLBuilderPort,
   criteria: QueryCriteriaInterface,
   options: Partial<BuildSqlOptions> = {},
 ) {
   const o = { ...defaults, ...options }
-  // Reverted: original behavior (without guard against undefined in criteria.filter)
-  if (criteria.filter) {
-    const whole = createConditions()
-    for (const filter of Array.isArray(criteria.filter)
-      ? criteria.filter
-      : [criteria.filter]) {
-      // null/undefined要素をスキップ
-      if (!filter) continue
+  applyFilters(builder, criteria, o)
 
-      const cond = createConditions()
-      let hasCondition = false
-
-      // filter -> where
-      for (const name of keys(filter)) {
-        if (typeof name !== 'string') continue
-        if (/^having:/.test(name)) continue
-
-        const property = filter[name]
-        if (!property) continue
-
-        const { value, filter: customFilter } = property as FilterPayload
-        hasCondition = true
-
-        const columnName = (() => {
-          if (!property) return name
-          if (typeof property !== 'object') return name
-          if (!('column' in property)) return name
-          if (!property.column) return name
-          if (typeof property.column === 'string') return property.column
-          return property.column() as SQLBuilderPort
-        })()
-
-        createCond(cond, columnName, { value, filter: customFilter }, o)
-      }
-
-      if (hasCondition) {
-        whole.or(cond)
-      }
-    }
-    builder.where(whole)
-
-    // having support
-    const whole_having = createConditions()
-    for (const filter of Array.isArray(criteria.filter)
-      ? criteria.filter
-      : [criteria.filter]) {
-      // null/undefined要素をスキップ
-      if (!filter) continue
-
-      const cond = createConditions()
-      let hasHavingCondition = false
-
-      // filter -> having
-      for (const having_name of keys(filter)) {
-        if (typeof having_name !== 'string') continue
-        if (!/^having:/.test(having_name)) continue
-
-        const property = filter[having_name]
-        if (!property) continue
-
-        const { value, filter: customFilter } = property as FilterPayload
-        const name = having_name.replace(/^having:/, '')
-        hasHavingCondition = true
-
-        const columnName = (() => {
-          if (!property) return name
-          if (typeof property !== 'object') return name
-          if (!('column' in property)) return name
-          if (!property.column) return name
-          if (typeof property.column === 'string') return property.column
-          return property.column() as SQLBuilderPort
-        })()
-
-        createCond(cond, columnName, { value, filter: customFilter }, o)
-      }
-
-      if (hasHavingCondition) {
-        whole_having.or(cond)
-      }
-    }
-    builder.having(whole_having)
-  }
-
-  // orderBy
   if (criteria.orderBy) {
     const { orderBy } = criteria
     const orders = Array.isArray(orderBy) ? orderBy : [orderBy]
@@ -158,16 +159,29 @@ export function buildSQL<Driver extends QueryDriverInterface>(
     }
   }
 
-  // take -> limit
   if (criteria.take) {
     builder.limit(criteria.take)
   }
 
-  // skip -> offset
   if (criteria.skip) {
     builder.offset(criteria.skip)
   }
 
+  return builder.toSQL()
+}
+
+export function buildCountSQL<Driver extends QueryDriverInterface>(
+  builder: SQLBuilderPort,
+  criteria: QueryCriteriaInterface,
+  options: Partial<BuildSqlOptions> = {},
+) {
+  const o = { ...defaults, ...options }
+  // NOTE: coral-sql の select() に "SELECT " で始まる文字列を渡すと
+  // SELECT 句全体を上書きする挙動になる。これを利用して、source 関数で
+  // 組み立てられた column(...) 群を捨てて COUNT(*) クエリに差し替える。
+  // 結果セットのエイリアスは `count` 固定で、ドライバ側は row.count として参照する。
+  builder.select('SELECT COUNT(*) AS `count`')
+  applyFilters(builder, criteria, o)
   return builder.toSQL()
 }
 

--- a/packages/query-module-sql-builder/src/sql-builder.ts
+++ b/packages/query-module-sql-builder/src/sql-builder.ts
@@ -175,7 +175,7 @@ export function buildSQL<Driver extends QueryDriverInterface>(
   return builder.toSQL()
 }
 
-export function buildCountSQL<Driver extends QueryDriverInterface>(
+export function buildCountSQL(
   builder: SQLBuilderPort,
   criteria: QueryCriteriaInterface,
   options: Partial<BuildSqlOptions> = {},

--- a/packages/query-module/README.md
+++ b/packages/query-module/README.md
@@ -92,6 +92,32 @@ if (row === null) {
 }
 ```
 
+#### `.count(params = {})`
+
+Count rows matching params and return a number. The method is only available
+on the runner type when `count: true` is set on the query specification.
+
+```ts
+const userQuery = defineQuery<Data, QueryDriverPrisma>(driver, {
+  source: (builder) => builder.from('users'),
+  rules: { status: 'status' },
+  count: true, // <- enable count() on the runner
+})
+
+const total = await userQuery.count()
+const activeCount = await userQuery.count({
+  filter: { status: { eq: 'active' } },
+})
+```
+
+`count()` accepts the same shape as `many()` for API consistency, but only
+`filter` is honored — `orderBy`, `take`, and `skip` are ignored because they
+do not affect the resulting row count. Middleware `preprocess` runs (so
+default filters set there are applied) but `postprocess` does not, since the
+return value is a `number` rather than a `QueryResultList`.
+
+If `count` is omitted or `false`, `runner.count(...)` is a TypeScript error.
+
 ### Finding parameters
 
 The implementation of these parameters is left to the driver.

--- a/packages/query-module/README.md
+++ b/packages/query-module/README.md
@@ -94,14 +94,16 @@ if (row === null) {
 
 #### `.count(params = {})`
 
-Count rows matching params and return a number. The method is only available
-on the runner type when `count: true` is set on the query specification.
+Count rows matching params and return a number. The method is only exposed
+when the query is created via `defineQueryWithCount`. Runners returned from
+the regular `defineQuery` do not have `count()` on their type.
 
 ```ts
-const userQuery = defineQuery<Data, QueryDriverPrisma>(driver, {
+import { defineQueryWithCount } from '@rym-lib/query-module'
+
+const userQuery = defineQueryWithCount<Data, QueryDriverPrisma>(driver, {
   source: (builder) => builder.from('users'),
   rules: { status: 'status' },
-  count: true, // <- enable count() on the runner
 })
 
 const total = await userQuery.count()
@@ -116,10 +118,9 @@ do not affect the resulting row count. Middleware `preprocess` runs (so
 default filters set there are applied) but `postprocess` does not, since the
 return value is a `number` rather than a `QueryResultList`.
 
-If `count` is omitted or `false`, `runner.count(...)` is a TypeScript error.
-When `count: true` is set, the driver must implement `executeCount` —
-`defineQuery` enforces this via overload, so a driver without `executeCount`
-fails to type-check at the call site.
+`defineQueryWithCount` constrains its driver argument to
+`QueryDriverWithCountInterface`, so a driver that doesn't implement
+`executeCount` is rejected at compile time.
 
 ### Finding parameters
 

--- a/packages/query-module/README.md
+++ b/packages/query-module/README.md
@@ -117,6 +117,9 @@ default filters set there are applied) but `postprocess` does not, since the
 return value is a `number` rather than a `QueryResultList`.
 
 If `count` is omitted or `false`, `runner.count(...)` is a TypeScript error.
+When `count: true` is set, the driver must implement `executeCount` —
+`defineQuery` enforces this via overload, so a driver without `executeCount`
+fails to type-check at the call site.
 
 ### Finding parameters
 

--- a/packages/query-module/src/functions/define-query.ts
+++ b/packages/query-module/src/functions/define-query.ts
@@ -15,42 +15,6 @@ import { QueryRunner } from '../runner'
 
 export function defineQuery<
   Data extends QueryResultData,
-  Driver extends QueryDriverWithCountInterface = QueryDriverWithCountInterface,
-  List extends QueryResultList<Data> = QueryResultList<Data>,
-  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
->(
-  driver: Driver,
-  spec: QuerySpecification<Data, Driver, List, Params> & { count: true },
-  context?: Partial<QueryRunnerContext>,
-  options?: {
-    builder: (
-      driver: Driver,
-      spec: QuerySpecification<Data, Driver, List, Params>,
-      context: QueryRunnerContext,
-    ) => QueryRunnerInterface<Data, List, Params>
-  },
-): QueryRunnerWithCount<Data, List, Params>
-export function defineQuery<
-  Data extends QueryResultData,
-  Driver extends QueryDriverInterface = QueryDriverInterface,
-  List extends QueryResultList<Data> = QueryResultList<Data>,
-  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
->(
-  driver: Driver,
-  spec: QuerySpecification<Data, Driver, List, Params> & {
-    count?: false | undefined
-  },
-  context?: Partial<QueryRunnerContext>,
-  options?: {
-    builder: (
-      driver: Driver,
-      spec: QuerySpecification<Data, Driver, List, Params>,
-      context: QueryRunnerContext,
-    ) => QueryRunnerInterface<Data, List, Params>
-  },
-): QueryRunnerBase<Data, List, Params>
-export function defineQuery<
-  Data extends QueryResultData,
   Driver extends QueryDriverInterface = QueryDriverInterface,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
@@ -65,7 +29,7 @@ export function defineQuery<
       context: QueryRunnerContext,
     ) => QueryRunnerInterface<Data, List, Params>
   },
-): QueryRunnerInterface<Data, List, Params> {
+): QueryRunnerBase<Data, List, Params> {
   const ctx: QueryRunnerContext = {
     ...context,
     logger: context.logger ? context.logger : createLogger(),
@@ -74,4 +38,44 @@ export function defineQuery<
   return options?.builder
     ? options.builder(driver, spec, ctx)
     : new QueryRunner<Data, Driver, List, Params>(driver, spec, ctx)
+}
+
+/**
+ * Variant of {@link defineQuery} that exposes `count()` on the runner.
+ *
+ * Use this when the query spec opts into count support. The driver is
+ * constrained to {@link QueryDriverWithCountInterface}, so a driver that
+ * doesn't implement `executeCount` is rejected at compile time.
+ */
+export function defineQueryWithCount<
+  Data extends QueryResultData,
+  Driver extends QueryDriverWithCountInterface = QueryDriverWithCountInterface,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+>(
+  driver: Driver,
+  spec: QuerySpecification<Data, Driver, List, Params>,
+  context: Partial<QueryRunnerContext> = {},
+  options?: {
+    builder: (
+      driver: Driver,
+      spec: QuerySpecification<Data, Driver, List, Params>,
+      context: QueryRunnerContext,
+    ) => QueryRunnerInterface<Data, List, Params>
+  },
+): QueryRunnerWithCount<Data, List, Params> {
+  const ctx: QueryRunnerContext = {
+    ...context,
+    logger: context.logger ? context.logger : createLogger(),
+  }
+
+  const runner = options?.builder
+    ? options.builder(driver, { ...spec, count: true }, ctx)
+    : new QueryRunner<Data, Driver, List, Params>(
+        driver,
+        { ...spec, count: true },
+        ctx,
+      )
+
+  return runner as QueryRunnerWithCount<Data, List, Params>
 }

--- a/packages/query-module/src/functions/define-query.ts
+++ b/packages/query-module/src/functions/define-query.ts
@@ -1,5 +1,6 @@
 import {
   QueryDriverInterface,
+  QueryDriverWithCountInterface,
   QueryResultData,
   QueryResultList,
   QueryRunnerBase,
@@ -14,18 +15,48 @@ import { QueryRunner } from '../runner'
 
 export function defineQuery<
   Data extends QueryResultData,
+  Driver extends QueryDriverWithCountInterface = QueryDriverWithCountInterface,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+>(
+  driver: Driver,
+  spec: QuerySpecification<Data, Driver, List, Params> & { count: true },
+  context?: Partial<QueryRunnerContext>,
+  options?: {
+    builder: (
+      driver: Driver,
+      spec: QuerySpecification<Data, Driver, List, Params>,
+      context: QueryRunnerContext,
+    ) => QueryRunnerInterface<Data, List, Params>
+  },
+): QueryRunnerWithCount<Data, List, Params>
+export function defineQuery<
+  Data extends QueryResultData,
   Driver extends QueryDriverInterface = QueryDriverInterface,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
-  const Spec extends QuerySpecification<
-    Data,
-    Driver,
-    List,
-    Params
-  > = QuerySpecification<Data, Driver, List, Params>,
 >(
   driver: Driver,
-  spec: Spec,
+  spec: QuerySpecification<Data, Driver, List, Params> & {
+    count?: false | undefined
+  },
+  context?: Partial<QueryRunnerContext>,
+  options?: {
+    builder: (
+      driver: Driver,
+      spec: QuerySpecification<Data, Driver, List, Params>,
+      context: QueryRunnerContext,
+    ) => QueryRunnerInterface<Data, List, Params>
+  },
+): QueryRunnerBase<Data, List, Params>
+export function defineQuery<
+  Data extends QueryResultData,
+  Driver extends QueryDriverInterface = QueryDriverInterface,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+>(
+  driver: Driver,
+  spec: QuerySpecification<Data, Driver, List, Params>,
   context: Partial<QueryRunnerContext> = {},
   options?: {
     builder: (
@@ -34,19 +65,13 @@ export function defineQuery<
       context: QueryRunnerContext,
     ) => QueryRunnerInterface<Data, List, Params>
   },
-): Spec['count'] extends true
-  ? QueryRunnerWithCount<Data, List, Params>
-  : QueryRunnerBase<Data, List, Params> {
+): QueryRunnerInterface<Data, List, Params> {
   const ctx: QueryRunnerContext = {
     ...context,
     logger: context.logger ? context.logger : createLogger(),
   }
 
-  const runner = options?.builder
+  return options?.builder
     ? options.builder(driver, spec, ctx)
     : new QueryRunner<Data, Driver, List, Params>(driver, spec, ctx)
-
-  return runner as Spec['count'] extends true
-    ? QueryRunnerWithCount<Data, List, Params>
-    : QueryRunnerBase<Data, List, Params>
 }

--- a/packages/query-module/src/functions/define-query.ts
+++ b/packages/query-module/src/functions/define-query.ts
@@ -2,9 +2,11 @@ import {
   QueryDriverInterface,
   QueryResultData,
   QueryResultList,
+  QueryRunnerBase,
   QueryRunnerContext,
   QueryRunnerCriteria,
   QueryRunnerInterface,
+  QueryRunnerWithCount,
   QuerySpecification,
 } from '../interfaces'
 import { createLogger } from '../logger'
@@ -15,9 +17,15 @@ export function defineQuery<
   Driver extends QueryDriverInterface = QueryDriverInterface,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+  const Spec extends QuerySpecification<
+    Data,
+    Driver,
+    List,
+    Params
+  > = QuerySpecification<Data, Driver, List, Params>,
 >(
   driver: Driver,
-  spec: QuerySpecification<Data, Driver, List, Params>,
+  spec: Spec,
   context: Partial<QueryRunnerContext> = {},
   options?: {
     builder: (
@@ -26,13 +34,19 @@ export function defineQuery<
       context: QueryRunnerContext,
     ) => QueryRunnerInterface<Data, List, Params>
   },
-): QueryRunnerInterface<Data, List, Params> {
+): Spec['count'] extends true
+  ? QueryRunnerWithCount<Data, List, Params>
+  : QueryRunnerBase<Data, List, Params> {
   const ctx: QueryRunnerContext = {
     ...context,
     logger: context.logger ? context.logger : createLogger(),
   }
 
-  return options?.builder
+  const runner = options?.builder
     ? options.builder(driver, spec, ctx)
     : new QueryRunner<Data, Driver, List, Params>(driver, spec, ctx)
+
+  return runner as Spec['count'] extends true
+    ? QueryRunnerWithCount<Data, List, Params>
+    : QueryRunnerBase<Data, List, Params>
 }

--- a/packages/query-module/src/functions/define-query.ts
+++ b/packages/query-module/src/functions/define-query.ts
@@ -61,7 +61,7 @@ export function defineQueryWithCount<
       driver: Driver,
       spec: QuerySpecification<Data, Driver, List, Params>,
       context: QueryRunnerContext,
-    ) => QueryRunnerInterface<Data, List, Params>
+    ) => QueryRunnerWithCount<Data, List, Params>
   },
 ): QueryRunnerWithCount<Data, List, Params> {
   const ctx: QueryRunnerContext = {
@@ -69,13 +69,12 @@ export function defineQueryWithCount<
     logger: context.logger ? context.logger : createLogger(),
   }
 
-  const runner = options?.builder
-    ? options.builder(driver, { ...spec, count: true }, ctx)
-    : new QueryRunner<Data, Driver, List, Params>(
-        driver,
-        { ...spec, count: true },
-        ctx,
-      )
-
-  return runner as QueryRunnerWithCount<Data, List, Params>
+  if (options?.builder) {
+    return options.builder(driver, { ...spec, count: true }, ctx)
+  }
+  return new QueryRunner<Data, Driver, List, Params>(
+    driver,
+    { ...spec, count: true },
+    ctx,
+  )
 }

--- a/packages/query-module/src/index.ts
+++ b/packages/query-module/src/index.ts
@@ -13,9 +13,11 @@ export type {
   QueryLoggerInterface,
   QueryResultData,
   QueryResultList,
+  QueryRunnerBase,
   QueryRunnerContext,
   QueryRunnerCriteria,
   QueryRunnerInterface,
   QueryRunnerMiddleware,
+  QueryRunnerWithCount,
   QuerySpecification,
 } from './interfaces'

--- a/packages/query-module/src/index.ts
+++ b/packages/query-module/src/index.ts
@@ -8,6 +8,7 @@ export type {
   QueryCriteriaInterface,
   QueryDriverCustomFilterFunction,
   QueryDriverInterface,
+  QueryDriverWithCountInterface,
   QueryFilter,
   QueryFilterOperator,
   QueryLoggerInterface,

--- a/packages/query-module/src/index.ts
+++ b/packages/query-module/src/index.ts
@@ -1,6 +1,6 @@
 export { QueryCriteria } from './criteria'
 export { QueryRunnerResourceNotFoundException } from './exceptions'
-export { defineQuery } from './functions/define-query'
+export { defineQuery, defineQueryWithCount } from './functions/define-query'
 export { QueryRunner } from './runner'
 
 export type {

--- a/packages/query-module/src/interfaces.ts
+++ b/packages/query-module/src/interfaces.ts
@@ -81,7 +81,7 @@ export interface QueryCriteriaInterface<Data extends QueryResultData = any> {
   readonly skip: QueryCriteriaSkip
 }
 
-export interface QueryRunnerBase<
+export interface QueryRunnerInterface<
   Data extends QueryResultData,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
@@ -91,22 +91,19 @@ export interface QueryRunnerBase<
   find(params: Params): Promise<Data>
 }
 
+export type QueryRunnerBase<
+  Data extends QueryResultData,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+> = QueryRunnerInterface<Data, List, Params>
+
 export interface QueryRunnerWithCount<
   Data extends QueryResultData,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
-> extends QueryRunnerBase<Data, List, Params> {
+> extends QueryRunnerInterface<Data, List, Params> {
   count(params?: Params): Promise<number>
 }
-
-export type QueryRunnerInterface<
-  Data extends QueryResultData,
-  List extends QueryResultList<Data> = QueryResultList<Data>,
-  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
-  Spec extends { count?: boolean } = { count?: boolean },
-> = Spec['count'] extends true
-  ? QueryRunnerWithCount<Data, List, Params>
-  : QueryRunnerBase<Data, List, Params>
 
 export interface QueryRunnerContext {
   logger: QueryLoggerInterface

--- a/packages/query-module/src/interfaces.ts
+++ b/packages/query-module/src/interfaces.ts
@@ -131,8 +131,12 @@ export interface QueryDriverInterface {
   execute<D>(
     criteria: QueryCriteriaInterface<D>,
   ): Promise<Record<string, any>[]>
-  executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number>
+  executeCount?<D>(criteria: QueryCriteriaInterface<D>): Promise<number>
   customFilter?: QueryDriverCustomFilterFunction
+}
+
+export interface QueryDriverWithCountInterface extends QueryDriverInterface {
+  executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number>
 }
 
 interface QuerySourceInterface<

--- a/packages/query-module/src/interfaces.ts
+++ b/packages/query-module/src/interfaces.ts
@@ -81,7 +81,7 @@ export interface QueryCriteriaInterface<Data extends QueryResultData = any> {
   readonly skip: QueryCriteriaSkip
 }
 
-export interface QueryRunnerInterface<
+export interface QueryRunnerBase<
   Data extends QueryResultData,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
@@ -90,6 +90,23 @@ export interface QueryRunnerInterface<
   many(params?: Params): Promise<List>
   find(params: Params): Promise<Data>
 }
+
+export interface QueryRunnerWithCount<
+  Data extends QueryResultData,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+> extends QueryRunnerBase<Data, List, Params> {
+  count(params?: Params): Promise<number>
+}
+
+export type QueryRunnerInterface<
+  Data extends QueryResultData,
+  List extends QueryResultList<Data> = QueryResultList<Data>,
+  Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
+  Spec extends { count?: boolean } = { count?: boolean },
+> = Spec['count'] extends true
+  ? QueryRunnerWithCount<Data, List, Params>
+  : QueryRunnerBase<Data, List, Params>
 
 export interface QueryRunnerContext {
   logger: QueryLoggerInterface
@@ -114,6 +131,7 @@ export interface QueryDriverInterface {
   execute<D>(
     criteria: QueryCriteriaInterface<D>,
   ): Promise<Record<string, any>[]>
+  executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number>
   customFilter?: QueryDriverCustomFilterFunction
 }
 
@@ -185,6 +203,7 @@ export interface QuerySpecification<
   >
   criteria?: (params: Partial<Params>) => Partial<Params>
   middlewares?: QueryRunnerMiddleware<Data, List, Params>[]
+  count?: boolean
 }
 
 export interface QueryLoggerInterface {

--- a/packages/query-module/src/runner.count.spec.ts
+++ b/packages/query-module/src/runner.count.spec.ts
@@ -54,7 +54,9 @@ describe('QueryRunner - Method: count(params?)', () => {
 
       expect(driver.called[0]!.method).toBe('executeCount')
       const criteria = driver.called[0]!.args[0]
-      expect(criteria.filter).toBeDefined()
+      expect(criteria.filter).toMatchObject({
+        status: { value: { eq: 'active' } },
+      })
     })
 
     it('should return number reflecting driver result', async () => {

--- a/packages/query-module/src/runner.count.spec.ts
+++ b/packages/query-module/src/runner.count.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { defineQuery } from './functions/define-query'
+import { defineQuery, defineQueryWithCount } from './functions/define-query'
 import { QueryRunnerMiddleware, QueryRunnerWithCount } from './interfaces'
 import { createDriver, TestDriver } from './test-utils/test-driver'
 
@@ -23,15 +23,14 @@ describe('QueryRunner - Method: count(params?)', () => {
     driver = createDriver()
   })
 
-  describe('When spec.count is true', () => {
+  describe('defineQueryWithCount exposes count()', () => {
     let runner: QueryRunnerWithCount<TestData>
 
     beforeEach(() => {
-      runner = defineQuery<TestData>(driver, {
+      runner = defineQueryWithCount<TestData>(driver, {
         name: 'test-count',
         source: () => testData,
         rules: { status: 'status' },
-        count: true,
       })
     })
 
@@ -80,12 +79,11 @@ describe('QueryRunner - Method: count(params?)', () => {
     it('should run preprocess middleware', async () => {
       const preprocess = vi.fn()
       const middleware: QueryRunnerMiddleware<TestData> = { preprocess }
-      const r = defineQuery<TestData>(driver, {
+      const r = defineQueryWithCount<TestData>(driver, {
         name: 'mw-count',
         source: () => testData,
         rules: {},
         middlewares: [middleware],
-        count: true,
       })
 
       await r.count()
@@ -96,12 +94,11 @@ describe('QueryRunner - Method: count(params?)', () => {
     it('should not run postprocess middleware', async () => {
       const postprocess = vi.fn()
       const middleware: QueryRunnerMiddleware<TestData> = { postprocess }
-      const r = defineQuery<TestData>(driver, {
+      const r = defineQueryWithCount<TestData>(driver, {
         name: 'mw-count',
         source: () => testData,
         rules: {},
         middlewares: [middleware],
-        count: true,
       })
 
       await r.count()
@@ -111,7 +108,7 @@ describe('QueryRunner - Method: count(params?)', () => {
 
     it('should run multiple preprocess middlewares in registration order', async () => {
       const order: string[] = []
-      const r = defineQuery<TestData>(driver, {
+      const r = defineQueryWithCount<TestData>(driver, {
         name: 'mw-order',
         source: () => testData,
         rules: {},
@@ -119,7 +116,6 @@ describe('QueryRunner - Method: count(params?)', () => {
           { preprocess: () => void order.push('first') },
           { preprocess: () => void order.push('second') },
         ],
-        count: true,
       })
 
       await r.count()
@@ -128,12 +124,11 @@ describe('QueryRunner - Method: count(params?)', () => {
     })
 
     it('should pass spec.criteria-transformed params to driver.executeCount', async () => {
-      const r = defineQuery<TestData>(driver, {
+      const r = defineQueryWithCount<TestData>(driver, {
         name: 'criteria-count',
         source: () => testData,
         rules: { status: 'status' },
         criteria: () => ({ filter: { status: { eq: 'active' } } }),
-        count: true,
       })
 
       await r.count()
@@ -150,7 +145,7 @@ describe('QueryRunner - Method: count(params?)', () => {
     })
   })
 
-  describe('When spec.count is not set', () => {
+  describe('defineQuery does not expose count()', () => {
     it('should not expose count() in the returned type', () => {
       const runner = defineQuery<TestData>(driver, {
         name: 'no-count',
@@ -158,27 +153,13 @@ describe('QueryRunner - Method: count(params?)', () => {
         rules: {},
       })
 
-      // @ts-expect-error - count is not available when spec.count is not true
-      runner.count
-    })
-  })
-
-  describe('When spec.count is false', () => {
-    it('should not expose count() in the returned type', () => {
-      const runner = defineQuery<TestData>(driver, {
-        name: 'no-count',
-        source: () => testData,
-        rules: {},
-        count: false,
-      })
-
-      // @ts-expect-error - count is not available when spec.count is false
+      // @ts-expect-error - count is not available on runners from defineQuery
       runner.count
     })
   })
 
   describe('Type-level driver requirement', () => {
-    it('should reject drivers without executeCount when spec.count is true', () => {
+    it('should reject drivers without executeCount in defineQueryWithCount', () => {
       const driverWithoutCount: import('./interfaces').QueryDriverInterface = {
         source() {
           return this
@@ -188,17 +169,17 @@ describe('QueryRunner - Method: count(params?)', () => {
         },
       }
 
-      // Type-only assertion: this call is wrapped in a never-executed branch
-      // so we only verify the @ts-expect-error directive triggers correctly.
+      // Type-only check: defineQueryWithCount constrains the driver to
+      // QueryDriverWithCountInterface, so a driver missing executeCount is
+      // a compile-time error. We don't execute the call.
       const _typeCheck = () =>
-        defineQuery<TestData>(
-          // @ts-expect-error - driver missing executeCount cannot be used with count: true
+        defineQueryWithCount<TestData>(
+          // @ts-expect-error - driver missing executeCount cannot be used with defineQueryWithCount
           driverWithoutCount,
           {
             name: 'no-execute-count-driver',
             source: () => testData,
             rules: {},
-            count: true,
           },
         )
       expect(typeof _typeCheck).toBe('function')

--- a/packages/query-module/src/runner.count.spec.ts
+++ b/packages/query-module/src/runner.count.spec.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { defineQuery } from './functions/define-query'
+import { QueryRunnerMiddleware, QueryRunnerWithCount } from './interfaces'
+import { createDriver, TestDriver } from './test-utils/test-driver'
+
+type TestData = {
+  id: number
+  name: string
+  status: 'active' | 'inactive'
+}
+
+const testData: TestData[] = [
+  { id: 1, name: 'Alice', status: 'active' },
+  { id: 2, name: 'Bob', status: 'inactive' },
+  { id: 3, name: 'Charlie', status: 'active' },
+]
+
+describe('QueryRunner - Method: count(params?)', () => {
+  let driver: TestDriver
+
+  beforeEach(() => {
+    driver = createDriver()
+  })
+
+  describe('When spec.count is true', () => {
+    let runner: QueryRunnerWithCount<TestData>
+
+    beforeEach(() => {
+      runner = defineQuery<TestData>(driver, {
+        name: 'test-count',
+        source: () => testData,
+        rules: { status: 'status' },
+        count: true,
+      })
+    })
+
+    it('should call driver.executeCount with criteria', async () => {
+      await runner.count()
+
+      expect(driver.called).toHaveLength(1)
+      expect(driver.called[0]!.method).toBe('executeCount')
+    })
+
+    it('should return total count without filter', async () => {
+      const count = await runner.count()
+
+      expect(count).toBe(3)
+    })
+
+    it('should pass filter criteria to driver.executeCount', async () => {
+      await runner.count({
+        filter: { status: { eq: 'active' } },
+      })
+
+      expect(driver.called[0]!.method).toBe('executeCount')
+      const criteria = driver.called[0]!.args[0]
+      expect(criteria.filter).toBeDefined()
+    })
+
+    it('should return number reflecting driver result', async () => {
+      driver.returns([
+        { id: 1, name: 'Alice', status: 'active' },
+        { id: 2, name: 'Bob', status: 'inactive' },
+      ])
+      const count = await runner.count()
+
+      expect(count).toBe(2)
+    })
+
+    it('should not mutate caller params', async () => {
+      const params = { filter: { status: { eq: 'active' } } }
+      const snapshot = JSON.parse(JSON.stringify(params))
+
+      await runner.count(params)
+
+      expect(params).toEqual(snapshot)
+    })
+
+    it('should run preprocess middleware', async () => {
+      const preprocess = vi.fn()
+      const middleware: QueryRunnerMiddleware<TestData> = { preprocess }
+      const r = defineQuery<TestData>(driver, {
+        name: 'mw-count',
+        source: () => testData,
+        rules: {},
+        middlewares: [middleware],
+        count: true,
+      })
+
+      await r.count()
+
+      expect(preprocess).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not run postprocess middleware', async () => {
+      const postprocess = vi.fn()
+      const middleware: QueryRunnerMiddleware<TestData> = { postprocess }
+      const r = defineQuery<TestData>(driver, {
+        name: 'mw-count',
+        source: () => testData,
+        rules: {},
+        middlewares: [middleware],
+        count: true,
+      })
+
+      await r.count()
+
+      expect(postprocess).not.toHaveBeenCalled()
+    })
+
+    it('should run multiple preprocess middlewares in registration order', async () => {
+      const order: string[] = []
+      const r = defineQuery<TestData>(driver, {
+        name: 'mw-order',
+        source: () => testData,
+        rules: {},
+        middlewares: [
+          { preprocess: () => void order.push('first') },
+          { preprocess: () => void order.push('second') },
+        ],
+        count: true,
+      })
+
+      await r.count()
+
+      expect(order).toEqual(['first', 'second'])
+    })
+
+    it('should pass spec.criteria-transformed params to driver.executeCount', async () => {
+      const r = defineQuery<TestData>(driver, {
+        name: 'criteria-count',
+        source: () => testData,
+        rules: { status: 'status' },
+        criteria: () => ({ filter: { status: { eq: 'active' } } }),
+        count: true,
+      })
+
+      await r.count()
+
+      const passedCriteria = driver.called[0]!.args[0]
+      expect(passedCriteria.filter).toBeDefined()
+    })
+
+    it('should return 0 when driver reports no rows', async () => {
+      driver.returns([])
+      const count = await runner.count()
+
+      expect(count).toBe(0)
+    })
+  })
+
+  describe('When spec.count is not set', () => {
+    it('should not expose count() in the returned type', () => {
+      const runner = defineQuery<TestData>(driver, {
+        name: 'no-count',
+        source: () => testData,
+        rules: {},
+      })
+
+      // @ts-expect-error - count is not available when spec.count is not true
+      runner.count
+    })
+  })
+
+  describe('When spec.count is false', () => {
+    it('should not expose count() in the returned type', () => {
+      const runner = defineQuery<TestData>(driver, {
+        name: 'no-count',
+        source: () => testData,
+        rules: {},
+        count: false,
+      })
+
+      // @ts-expect-error - count is not available when spec.count is false
+      runner.count
+    })
+  })
+})

--- a/packages/query-module/src/runner.count.spec.ts
+++ b/packages/query-module/src/runner.count.spec.ts
@@ -176,4 +176,32 @@ describe('QueryRunner - Method: count(params?)', () => {
       runner.count
     })
   })
+
+  describe('Type-level driver requirement', () => {
+    it('should reject drivers without executeCount when spec.count is true', () => {
+      const driverWithoutCount: import('./interfaces').QueryDriverInterface = {
+        source() {
+          return this
+        },
+        async execute() {
+          return []
+        },
+      }
+
+      // Type-only assertion: this call is wrapped in a never-executed branch
+      // so we only verify the @ts-expect-error directive triggers correctly.
+      const _typeCheck = () =>
+        defineQuery<TestData>(
+          // @ts-expect-error - driver missing executeCount cannot be used with count: true
+          driverWithoutCount,
+          {
+            name: 'no-execute-count-driver',
+            source: () => testData,
+            rules: {},
+            count: true,
+          },
+        )
+      expect(typeof _typeCheck).toBe('function')
+    })
+  })
 })

--- a/packages/query-module/src/runner.ts
+++ b/packages/query-module/src/runner.ts
@@ -10,7 +10,7 @@ import {
   QueryResultList,
   QueryRunnerContext,
   QueryRunnerCriteria,
-  QueryRunnerInterface,
+  QueryRunnerWithCount,
   QuerySpecification,
 } from './interfaces'
 
@@ -19,20 +19,20 @@ export class QueryRunner<
   Driver extends QueryDriverInterface,
   List extends QueryResultList<Data> = QueryResultList<Data>,
   Params extends QueryRunnerCriteria<Data> = QueryRunnerCriteria<Data>,
-> implements QueryRunnerInterface<Data, List>
+> implements QueryRunnerWithCount<Data, List, Params>
 {
   constructor(
     private driver: Driver,
     private spec: QuerySpecification<Data, Driver, List, Params>,
     private context: QueryRunnerContext,
   ) {
-    // Minimal validation to ensure required collaborators are present.
-    if (
-      !driver ||
-      typeof driver.source !== 'function' ||
-      typeof driver.execute !== 'function'
-    ) {
-      throw new TypeError('QueryRunner requires a valid QueryDriverInterface')
+    if (!driver) {
+      throw new TypeError('QueryRunner requires a driver')
+    }
+    for (const method of ['source', 'execute', 'executeCount'] as const) {
+      if (typeof driver[method] !== 'function') {
+        throw new TypeError(`QueryDriverInterface.${method} is required`)
+      }
     }
 
     if (!spec || typeof spec.source !== 'function') {
@@ -60,19 +60,7 @@ export class QueryRunner<
   }
 
   async many(params: Partial<Params> = {}): Promise<List> {
-    const pid = crypto.randomUUID()
-    for (const { preprocess } of this.spec.middlewares ?? []) {
-      if (!preprocess) continue
-      await preprocess(params, { ...this.context, pid, runner: this })
-    }
-
-    // Execute source function first to get the builder instance
-    const source = this.driver.source(this.spec.source)
-
-    const criteria = new QueryCriteria<Data>(
-      this.spec.rules,
-      this.spec.criteria ? this.spec.criteria(params) : params,
-    )
+    const { pid, source, criteria } = await this.prepare(params)
 
     const items = await source.execute(criteria)
     const result = {
@@ -98,5 +86,26 @@ export class QueryRunner<
     }
 
     return record
+  }
+
+  async count(params: Partial<Params> = {}): Promise<number> {
+    const { source, criteria } = await this.prepare(params)
+    return source.executeCount(criteria)
+  }
+
+  private async prepare(params: Partial<Params>) {
+    const pid = crypto.randomUUID()
+    for (const { preprocess } of this.spec.middlewares ?? []) {
+      if (!preprocess) continue
+      await preprocess(params, { ...this.context, pid, runner: this })
+    }
+
+    const source = this.driver.source(this.spec.source)
+    const criteria = new QueryCriteria<Data>(
+      this.spec.rules,
+      this.spec.criteria ? this.spec.criteria(params) : params,
+    )
+
+    return { pid, source, criteria }
   }
 }

--- a/packages/query-module/src/runner.ts
+++ b/packages/query-module/src/runner.ts
@@ -29,10 +29,15 @@ export class QueryRunner<
     if (!driver) {
       throw new TypeError('QueryRunner requires a driver')
     }
-    for (const method of ['source', 'execute', 'executeCount'] as const) {
+    for (const method of ['source', 'execute'] as const) {
       if (typeof driver[method] !== 'function') {
         throw new TypeError(`QueryDriverInterface.${method} is required`)
       }
+    }
+    if (spec?.count && typeof driver.executeCount !== 'function') {
+      throw new TypeError(
+        'QueryDriverInterface.executeCount is required when spec.count is true',
+      )
     }
 
     if (!spec || typeof spec.source !== 'function') {
@@ -90,6 +95,11 @@ export class QueryRunner<
 
   async count(params: Partial<Params> = {}): Promise<number> {
     const { source, criteria } = await this.prepare(params)
+    if (typeof source.executeCount !== 'function') {
+      throw new TypeError(
+        'QueryDriverInterface.executeCount is required when spec.count is true',
+      )
+    }
     return source.executeCount(criteria)
   }
 

--- a/packages/query-module/src/test-utils/run-middleware.ts
+++ b/packages/query-module/src/test-utils/run-middleware.ts
@@ -20,6 +20,10 @@ class DummyDriver implements QueryDriverInterface {
   ): Promise<Record<string, any>[]> {
     return []
   }
+
+  async executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number> {
+    return 0
+  }
 }
 
 export async function runMiddleware<Data>(

--- a/packages/query-module/src/test-utils/test-driver.ts
+++ b/packages/query-module/src/test-utils/test-driver.ts
@@ -7,7 +7,7 @@ class TestDriver<Data extends Record<string, any> = Record<string, any>>
   private data: null | Data[] = null
   private sourceFunction: (() => Data[]) | null = null
   public readonly called: {
-    method: 'execute'
+    method: 'execute' | 'executeCount'
     args: any[]
   }[] = []
 
@@ -38,6 +38,23 @@ class TestDriver<Data extends Record<string, any> = Record<string, any>>
 
     // For existing tests, return initial data
     return this.initial
+  }
+
+  async executeCount<D>(criteria: QueryCriteriaInterface<D>): Promise<number> {
+    this.called.push({
+      method: 'executeCount',
+      args: [criteria],
+    })
+
+    if (this.data && this.data !== this.initial) {
+      return this.data.length
+    }
+
+    if (this.shouldApplySmartFiltering(criteria)) {
+      return this.applySmartFiltering(criteria).length
+    }
+
+    return this.initial.length
   }
 
   private shouldApplySmartFiltering(


### PR DESCRIPTION
## Summary

`QueryRunner` に `count(params?): Promise<number>` を追加。型パズルにより、spec で `count: true` を指定したクエリだけランナーに `count()` が型として現れる。

- `count` は `filter` のみ評価（`orderBy` / `take` / `skip` は SQL に出力しない）
- ミドルウェアは `preprocess` のみ実行（`postprocess` は戻り値が `number` のためスキップ）
- SQL は `SELECT COUNT(*) AS \`count\``。Prisma の BigInt や Sequelize の文字列カウントを `Number()` に正規化

## ⚠ Breaking change

`QueryDriverInterface` に `executeCount` を**必須メソッド**として追加。リポジトリ内の Prisma / Sequelize / TestDriver / DummyDriver はすべて追従済み。**外部で独自に `QueryDriverInterface` を実装しているユーザーは追加実装が必要**。

→ リリース時にメジャーバンプ（または CHANGELOG での明示）を推奨。

## 主な変更点

- `query-module`
  - `QueryRunnerBase` / `QueryRunnerWithCount` を新設、`QueryRunnerInterface` を `Spec['count'] extends true ? ... : ...` の条件付き型に
  - `QuerySpecification.count?: boolean` を追加
  - `runner.ts` で `count()` 実装と preprocess/criteria 構築の `prepare()` 共通化
  - `defineQuery` を `const Spec` narrowing し、戻り型を分岐
- `query-module-sql-builder`
  - WHERE/HAVING 構築を `applyFilters` に抽出、`buildCountSQL` を新設
- `query-module-driver-{prisma,sequelize}`
  - `executeCount` を実装

## Test plan

- [x] `query-module`: 既存 175 + 新規 9 件すべて pass
- [x] `query-module-sql-builder`: `buildCountSQL` の SELECT/WHERE/orderBy無視/take無視 を網羅
- [x] `query-module-driver-prisma`: SQL 発行、count 値抽出、BigInt 変換、フォールバック、空結果、WHERE 連携
- [x] `query-module-driver-sequelize`: 同上（BigInt → 文字列ケース）
- [x] 型テスト: `count: true` で `runner.count(...)` 可、`count` 未指定 / `count: false` で `@ts-expect-error`
- [x] `npx turbo run build` 全パッケージ green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

`QueryRunner` に `count()` メソッドを追加し、`defineQueryWithCount` から返されるランナーにのみ型として公開する実装です。`applyFilters` の抽出、`buildCountSQL` の新設、Prisma/Sequelize ドライバへの `executeCount` 追加、型パズルによる条件付き型露出まで、一貫した設計でまとまっています。

<h3>Confidence Score: 5/5</h3>

マージしても安全です。指摘済みの問題（HAVING 混入・未使用型パラメータ・unsafe キャスト）はすべて修正済みで、新規バグは見当たりません。

P0/P1 の問題なし。テストカバレッジが十分で、既存動作への影響もない。

特に注意が必要なファイルはありません。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/query-module/src/runner.ts | `count()` メソッドと `prepare()` 共通化を追加。`QueryRunner` が `QueryRunnerWithCount` を実装するよう変更され、コンストラクタのバリデーションも整理されている。 |
| packages/query-module/src/interfaces.ts | `QueryRunnerBase`・`QueryRunnerWithCount`・`QueryDriverWithCountInterface` を新設し、`executeCount` をオプショナルとして `QueryDriverInterface` に追加。型設計は整合的。 |
| packages/query-module/src/functions/define-query.ts | `defineQueryWithCount` を新設し、`options.builder` の戻り型を `QueryRunnerWithCount` に正しく制約。以前のスレッドで指摘された unsafe キャスト問題は解消済み。 |
| packages/query-module-sql-builder/src/sql-builder.ts | `applyFilters` を抽出して `buildCountSQL` を新設。`skipHaving: true` で HAVING 句を抑制するフラグも正しく実装。`buildSQL` の既存動作に影響なし。 |
| packages/query-module-driver-prisma/src/driver.ts | `executeCount` を実装。BigInt → Number 変換・フォールバック処理・空結果ケースもカバー。 |
| packages/query-module-driver-sequelize/src/driver.ts | `executeCount` を実装。文字列カウント（Sequelize が返す場合）の `Number()` 正規化も含む。Prisma 実装と対称的。 |
| packages/query-module/src/runner.count.spec.ts | 新規テストファイル。preprocess 実行・postprocess スキップ・フィルタ受け渡し・型チェックなど網羅的なテストケースを追加。 |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant defineQueryWithCount
    participant QueryRunner
    participant Driver as QueryDriver
    participant buildCountSQL

    User->>defineQueryWithCount: defineQueryWithCount(driver, spec)
    defineQueryWithCount->>QueryRunner: new QueryRunner(driver, spec+count:true)
    defineQueryWithCount-->>User: QueryRunnerWithCount

    User->>QueryRunner: runner.count(params)
    QueryRunner->>QueryRunner: prepare(params) preprocessのみ実行
    QueryRunner->>Driver: source.executeCount(criteria)
    Driver->>buildCountSQL: buildCountSQL(builder, criteria)
    buildCountSQL->>buildCountSQL: "select COUNT(*) + applyFilters(skipHaving:true)"
    buildCountSQL-->>Driver: sql, replacements
    Driver->>Driver: db.queryRawUnsafe or db.query
    Driver-->>QueryRunner: Number(row.count)
    QueryRunner-->>User: number
```

<sub>Reviews (7): Last reviewed commit: ["fix(query-module): tighten options.build..."](https://github.com/rymizuki/rym-lib/commit/e315fef223b0ff706f0a7cb1becf7426a1b5682a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29959833)</sub>

<!-- /greptile_comment -->