### PR TITLE
fix(seeder): bigint型の主キー・カラムに対応する

### DIFF
--- a/packages/seeder/src/seeder.spec.ts
+++ b/packages/seeder/src/seeder.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+import { PrismaClient } from '@prisma/client'
+
 import { Seeder } from './seeder'
 
 const mockPrismaClient = {
@@ -8,12 +10,11 @@ const mockPrismaClient = {
 }
 
 describe('Seeder', () => {
-  let seeder: Seeder
+  const seeder = new Seeder(mockPrismaClient as unknown as PrismaClient, {})
 
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(console, 'info').mockImplementation(() => {})
-    seeder = new Seeder(mockPrismaClient as any, {})
   })
 
   describe('load', () => {
@@ -139,6 +140,27 @@ describe('Seeder', () => {
           )
 
           expect(mockPrismaClient.$executeRawUnsafe).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('シチュエーション: 対象の主キーの行が存在し、DateカラムのみDB側と異なる場合', () => {
+        it('結果: UPDATE文を実行する', async () => {
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+            { id: 1, published_at: new Date('2024-01-01T00:00:00.000Z') },
+          ])
+
+          await seeder.load(
+            'articles',
+            'id',
+            ['id', 'published_at'],
+            [[1, new Date('2024-06-01T00:00:00.000Z')]],
+          )
+
+          expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
+            'UPDATE `articles` SET `published_at` = $1 WHERE `id` = $2',
+            new Date('2024-06-01T00:00:00.000Z'),
+            1,
+          )
         })
       })
     })

--- a/packages/seeder/src/seeder.spec.ts
+++ b/packages/seeder/src/seeder.spec.ts
@@ -1,3 +1,146 @@
-import { describe } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-describe.todo('seeder', () => {})
+import { Seeder } from './seeder'
+
+const mockPrismaClient = {
+  $queryRawUnsafe: vi.fn(),
+  $executeRawUnsafe: vi.fn(),
+}
+
+describe('Seeder', () => {
+  let seeder: Seeder
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(console, 'info').mockImplementation(() => {})
+    seeder = new Seeder(mockPrismaClient as any, {})
+  })
+
+  describe('load', () => {
+    describe('ユースケース: bigintを主キーに持つテーブルへレコードを投入する', () => {
+      describe('シチュエーション: 対象の主キーの行が存在しない場合', () => {
+        beforeEach(() => {
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([])
+        })
+
+        it('結果: bigintの主キー値でINSERT文を実行する', async () => {
+          await seeder.load(
+            'users',
+            'id',
+            ['id', 'name'],
+            [[10n, 'test']],
+          )
+
+          expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
+            'INSERT INTO `users` (`id`, `name`) VALUES ($1, $2)',
+            10n,
+            'test',
+          )
+        })
+      })
+
+      describe('シチュエーション: 対象の主キーの行が存在し、DB側の値と異なる場合', () => {
+        beforeEach(() => {
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+            { id: 10n, name: 'old_name' },
+          ])
+        })
+
+        it('結果: bigintの主キー値でUPDATE文を実行する', async () => {
+          await seeder.load(
+            'users',
+            'id',
+            ['id', 'name'],
+            [[10n, 'new_name']],
+          )
+
+          expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
+            'UPDATE `users` SET `name` = $1 WHERE `id` = $2',
+            'new_name',
+            10n,
+          )
+        })
+      })
+
+      describe('シチュエーション: 対象の主キーの行が存在し、DB側の値と同じ(変更なし)場合', () => {
+        beforeEach(() => {
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+            { id: 10n, name: 'test' },
+          ])
+        })
+
+        it('結果: UPDATE・INSERTともに実行しない', async () => {
+          await seeder.load(
+            'users',
+            'id',
+            ['id', 'name'],
+            [[10n, 'test']],
+          )
+
+          expect(mockPrismaClient.$executeRawUnsafe).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('シチュエーション: DB側がbigintで返り、投入対象が同じ値のnumber/stringの場合', () => {
+        it.each([
+          { label: 'number', recordValue: 10 },
+          { label: 'string', recordValue: '10' },
+        ])(
+          '結果: 値の型が$labelでも同値であればUPDATEをスキップする',
+          async ({ recordValue }) => {
+            mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+              { id: 10n, name: 'test' },
+            ])
+
+            await seeder.load(
+              'users',
+              'id',
+              ['id', 'name'],
+              [[recordValue, 'test']],
+            )
+
+            expect(mockPrismaClient.$executeRawUnsafe).not.toHaveBeenCalled()
+          },
+        )
+      })
+    })
+
+    describe('ユースケース: bigintを含まないゼロ埋め文字列カラムを持つテーブルへレコードを投入する', () => {
+      describe('シチュエーション: 対象の主キーの行が存在し、DB側とゼロ埋め表記のみが異なる場合', () => {
+        it('結果: 数値としては同値でも文字列として異なるためUPDATE文を実行する', async () => {
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+            { id: 1, zip_code: '0001' },
+          ])
+
+          await seeder.load('offices', 'id', ['id', 'zip_code'], [[1, '001']])
+
+          expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
+            'UPDATE `offices` SET `zip_code` = $1 WHERE `id` = $2',
+            '001',
+            1,
+          )
+        })
+      })
+    })
+
+    describe('ユースケース: Dateカラムを持つテーブルへレコードを投入する', () => {
+      describe('シチュエーション: 対象の主キーの行が存在し、Dateカラムの値がDB側と同値の場合', () => {
+        it('結果: UPDATE・INSERTともに実行しない', async () => {
+          const sharedDate = new Date('2024-01-01T00:00:00.000Z')
+          mockPrismaClient.$queryRawUnsafe.mockResolvedValue([
+            { id: 1, published_at: new Date(sharedDate.getTime()) },
+          ])
+
+          await seeder.load(
+            'articles',
+            'id',
+            ['id', 'published_at'],
+            [[1, new Date(sharedDate.getTime())]],
+          )
+
+          expect(mockPrismaClient.$executeRawUnsafe).not.toHaveBeenCalled()
+        })
+      })
+    })
+  })
+})

--- a/packages/seeder/src/seeder.ts
+++ b/packages/seeder/src/seeder.ts
@@ -124,6 +124,9 @@ export class Seeder {
   /**
    * BigIntへ変換可能な値かどうかを判定する型ガード。
    * 数値・bigintに加え、整数のみからなる文字列を対象とする。
+   *
+   * NOTE: number型は`Number.MAX_SAFE_INTEGER`（2^53 - 1）以下でのみ正確に比較できる。
+   * それを超える値（Snowflake ID等）はnumberでは精度が失われるため、bigintまたは文字列で渡すこと。
    */
   private isNumericConvertible(
     value: unknown,

--- a/packages/seeder/src/seeder.ts
+++ b/packages/seeder/src/seeder.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client'
 
-type Value = string | number | Date | boolean
+type Value = string | number | bigint | Date | boolean
 
 export type SeederOptions = {
   created_at?: boolean
@@ -47,7 +47,9 @@ export class Seeder {
           continue
         }
         if (
-          !columns.filter((prop, index) => row[prop] !== record[index]).length
+          columns.every((prop, index) =>
+            this.isEqualValue(row[prop], record[index]),
+          )
         ) {
           // 対象が変更されてなかったらupdateしない
           continue
@@ -100,6 +102,42 @@ export class Seeder {
       }
     }
     console.info(`loading "${table_name}" done.`)
+  }
+
+  /**
+   * DBから取得した値とシード対象の値が等価かどうかを判定する。
+   * どちらか一方がbigintの場合のみ数値として正規化して比較し、Date同士は日時として比較する。
+   * bigintが関与しないnumber同士・string同士の比較は`===`に委ねる（ゼロ埋め文字列の誤同一視を避けるため）。
+   */
+  private isEqualValue(a: unknown, b: unknown): boolean {
+    if (typeof a === 'bigint' || typeof b === 'bigint') {
+      return this.isNumericConvertible(a) && this.isNumericConvertible(b)
+        ? BigInt(a) === BigInt(b)
+        : a === b
+    }
+    if (a instanceof Date && b instanceof Date) {
+      return a.getTime() === b.getTime()
+    }
+    return a === b
+  }
+
+  /**
+   * BigIntへ変換可能な値かどうかを判定する型ガード。
+   * 数値・bigintに加え、整数のみからなる文字列を対象とする。
+   */
+  private isNumericConvertible(
+    value: unknown,
+  ): value is string | number | bigint {
+    if (typeof value === 'bigint') {
+      return true
+    }
+    if (typeof value === 'number') {
+      return Number.isInteger(value)
+    }
+    if (typeof value === 'string') {
+      return /^-?\d+$/.test(value)
+    }
+    return false
   }
 
   private escape(value: string) {


### PR DESCRIPTION
## Summary
- `Value` 型に `bigint` を追加し、bigint PK/カラム（snowflake ID等）の値を型レベルで渡せるようにした
- 既存行との差分判定を `isEqualValue`/`isNumericConvertible` private メソッド経由にし、**どちらか一方が実際に bigint 型の場合のみ** bigint/整数number/整数文字列を数値として正規化して比較するようにした
  - 従来は `!==` の素朴比較だったため、`$queryRawUnsafe` が bigint カラムの値を BigInt で返すのに対し record 側が number/string だと常に不一致判定され、変更が無くても毎回 UPDATE が走っていた
  - number同士・string同士の比較は従来通り `===` のままなので、ゼロ埋め文字列カラム（郵便番号等）同士が誤って同一視されることはない
- 副次的に、Date同士の比較を `getTime()` による日時比較に修正（従来は参照比較のため常に不一致扱いだったバグ）

## Test plan
- [x] bigintを主キーに持つテーブルで、対象行が存在しない場合にbigintの主キー値でINSERT文を実行する
- [x] bigintを主キーに持つテーブルで、対象行が存在しDB側の値と異なる場合にUPDATE文を実行する
- [x] bigintを主キーに持つテーブルで、対象行が存在しDB側の値と同じ(変更なし)場合にUPDATE・INSERTともに実行しない
- [x] DB側がbigintで返り、投入対象が同じ値のnumber/stringの場合でも同値としてスキップする
- [x] ゼロ埋め文字列カラムのみ表記が異なる場合、数値としては同値でも文字列として異なるためUPDATE文を実行する（誤同一視の回帰テスト）
- [x] Dateカラムの値がDB側と同値の場合、UPDATE・INSERTともに実行しない

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

bigint 型の主キー・カラム値をシーダーで正しく扱えるようにした修正です。`Value` 型に `bigint` を追加し、既存行との差分判定を `isEqualValue` / `isNumericConvertible` 経由に変更することで、DB が BigInt で返す値とシード側の number / string を数値として正規化比較できるようになりました。

- **bigint 比較**: どちらか一方が bigint の場合のみ `BigInt()` で正規化して比較し、number 同士・string 同士は従来通り `===` のままにすることでゼロ埋め文字列の誤同一視を防止。
- **Date 比較**: 従来の参照比較（常に不一致）を `getTime()` による値比較に修正。
- **テスト**: INSERT / UPDATE / スキップ・異型同値・ゼロ埋め回帰・Date の各シナリオを網羅したテストスイートを追加。

<h3>Confidence Score: 5/5</h3>

比較ロジックの修正範囲が明確に限定されており、ゼロ埋め文字列等の既存動作への影響もテストで確認済み。マージして問題ありません。

isEqualValue / isNumericConvertible の判定ロジックが意図通りに実装されており、bigint 関与時のみ正規化比較・Date は getTime() 比較・それ以外は厳密等価という分岐が正確。ゼロ埋め文字列の誤同一視回帰テストも含まれており、既存動作への副作用がないことが確認できる。

特に注意が必要なファイルはありません。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/seeder/src/seeder.ts | Value 型に bigint を追加し、isEqualValue / isNumericConvertible の2つの private メソッドで値比較を正規化。bigint 関与時のみ数値正規化比較、Date 同士は getTime() 比較、それ以外は === という判定順序が正確に実装されている。 |
| packages/seeder/src/seeder.spec.ts | プレースホルダーの describe.todo から本格的なテストスイートへ移行。bigint PK の INSERT/UPDATE/スキップ・異型同値スキップ・ゼロ埋め回帰・Date 比較の各ケースを網羅している。 |

<sub>Reviews (2): Last reviewed commit: ["docs(seeder): number型seed値の安全整数上限をJSDocに..."](https://github.com/rymizuki/rym-lib/commit/c33a21bd76e62a85faba202cb96b95e47fcf69aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41855976)</sub>

<!-- /greptile_comment -->