### PR TITLE
v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16301,7 +16301,7 @@
     },
     "packages/exception": {
       "name": "@rym-lib/exception",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -16487,7 +16487,7 @@
     },
     "packages/inversify-bundler": {
       "name": "@rym-lib/inversify-bundler",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -16503,11 +16503,11 @@
     },
     "packages/inversify-bundler-express": {
       "name": "@rym-lib/inversify-bundler-express",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/inversify-bundler": "1.7.0",
+        "@rym-lib/inversify-bundler": "1.7.1",
         "@types/express": "^5.0.0",
         "@types/node": "^22.9.0",
         "express": "^4.21.1",
@@ -16516,7 +16516,7 @@
         "vitest": "^2.1.5"
       },
       "peerDependencies": {
-        "@rym-lib/inversify-bundler": ">=1.7.0",
+        "@rym-lib/inversify-bundler": ">=1.7.1",
         "express": ">=4.0.0"
       }
     },
@@ -16870,7 +16870,7 @@
     },
     "packages/nakadachi": {
       "name": "@rym-lib/nakadachi",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -16882,7 +16882,7 @@
     },
     "packages/nakadachi-adapter-react-router": {
       "name": "@rym-lib/nakadachi-adapter-react-router",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "qs": "^6.13.0",
@@ -16890,7 +16890,7 @@
       },
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "@types/node": "^22.4.1",
         "@types/qs": "^6.9.15",
         "npm-check-updates": "^17.0.6",
@@ -16898,7 +16898,7 @@
         "vitest": "^2.0.5"
       },
       "peerDependencies": {
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "react-router": "^7.8.0"
       }
     },
@@ -17101,7 +17101,7 @@
     },
     "packages/nakadachi-adapter-remix": {
       "name": "@rym-lib/nakadachi-adapter-remix",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "qs": "^6.13.0"
@@ -17109,7 +17109,7 @@
       "devDependencies": {
         "@remix-run/node": "^2.11.2",
         "@rym-lib/dev-config": "*",
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "@types/node": "^22.4.1",
         "@types/qs": "^6.9.15",
         "npm-check-updates": "^17.0.6",
@@ -17118,7 +17118,7 @@
       },
       "peerDependencies": {
         "@remix-run/node": "^2.11",
-        "@rym-lib/nakadachi": ">=1.7.0"
+        "@rym-lib/nakadachi": ">=1.7.1"
       }
     },
     "packages/nakadachi-adapter-remix/node_modules/@vitest/expect": {
@@ -17297,12 +17297,12 @@
     },
     "packages/nakadachi-interactor": {
       "name": "@rym-lib/nakadachi-interactor",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/inversify-bundler": ">=1.7.0",
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/inversify-bundler": ">=1.7.1",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "@types/node": "^22.9.0",
         "npm-check-updates": "^17.0.6",
         "reflect-metadata": "^0.2.2",
@@ -17310,20 +17310,20 @@
         "vitest": "^2.0.5"
       },
       "peerDependencies": {
-        "@rym-lib/exception": ">=1.7.0",
-        "@rym-lib/inversify-bundler": ">=1.7.0",
-        "@rym-lib/nakadachi": ">=1.7.0"
+        "@rym-lib/exception": ">=1.7.1",
+        "@rym-lib/inversify-bundler": ">=1.7.1",
+        "@rym-lib/nakadachi": ">=1.7.1"
       }
     },
     "packages/nakadachi-interactor-mixin-validator": {
       "name": "@rym-lib/nakadachi-interactor-mixin-validator",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/exception": "1.7.0",
-        "@rym-lib/inversify-bundler": ">=1.7.0",
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/exception": "1.7.1",
+        "@rym-lib/inversify-bundler": ">=1.7.1",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "@types/node": "^22.9.0",
         "npm-check-updates": "^17.0.6",
         "tsup": "^8.2.4",
@@ -17331,9 +17331,9 @@
         "zod": "^3.23.8"
       },
       "peerDependencies": {
-        "@rym-lib/exception": "1.7.0",
-        "@rym-lib/inversify-bundler": ">=1.7.0",
-        "@rym-lib/nakadachi": ">=1.7.0",
+        "@rym-lib/exception": "1.7.1",
+        "@rym-lib/inversify-bundler": ">=1.7.1",
+        "@rym-lib/nakadachi": ">=1.7.1",
         "zod": ">=3.0.0"
       }
     },
@@ -17861,14 +17861,14 @@
     },
     "packages/query-module": {
       "name": "@rym-lib/query-module",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@rym-lib/exception": "^1.7.0"
+        "@rym-lib/exception": "^1.7.1"
       },
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/utilities": "1.7.0",
+        "@rym-lib/utilities": "1.7.1",
         "@types/node": "^22.4.1",
         "@vitest/coverage-v8": "^3.0.3",
         "npm-check-updates": "^17.0.6",
@@ -17878,15 +17878,15 @@
     },
     "packages/query-module-driver-prisma": {
       "name": "@rym-lib/query-module-driver-prisma",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@rym-lib/query-module-sql-builder": "1.7.0"
+        "@rym-lib/query-module-sql-builder": "1.7.1"
       },
       "devDependencies": {
         "@prisma/client": "^5.22.0",
         "@rym-lib/dev-config": "*",
-        "@rym-lib/query-module": "1.7.0",
+        "@rym-lib/query-module": "1.7.1",
         "@types/node": "^22.4.1",
         "@vitest/coverage-v8": "^3.2.4",
         "npm-check-updates": "^17.0.6",
@@ -17901,14 +17901,14 @@
     },
     "packages/query-module-driver-sequelize": {
       "name": "@rym-lib/query-module-driver-sequelize",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@rym-lib/query-module-sql-builder": "1.7.0"
+        "@rym-lib/query-module-sql-builder": "1.7.1"
       },
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/query-module": "1.7.0",
+        "@rym-lib/query-module": "1.7.1",
         "@types/node": "^22.4.1",
         "@vitest/coverage-v8": "^3.2.4",
         "npm-check-updates": "^17.0.6",
@@ -17923,11 +17923,11 @@
     },
     "packages/query-module-pagination": {
       "name": "@rym-lib/query-module-pagination",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/query-module": "1.7.0",
+        "@rym-lib/query-module": "1.7.1",
         "@types/node": "^22.4.1",
         "npm-check-updates": "^17.0.6",
         "tsup": "^8.2.4",
@@ -18110,14 +18110,14 @@
     },
     "packages/query-module-sql-builder": {
       "name": "@rym-lib/query-module-sql-builder",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "coral-sql": "^1.5.3"
       },
       "devDependencies": {
         "@rym-lib/dev-config": "*",
-        "@rym-lib/query-module": "^1.7.0",
+        "@rym-lib/query-module": "^1.7.1",
         "@types/node": "^22.15.17",
         "@vitest/coverage-v8": "^3.1.3",
         "tsup": "^8.2.4",
@@ -18126,7 +18126,7 @@
     },
     "packages/rdb-command": {
       "name": "@rym-lib/rdb-command",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -18316,10 +18316,10 @@
     },
     "packages/remix-helper": {
       "name": "@rym-lib/remix-helper",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "@rym-lib/utilities": "^1.7.0"
+        "@rym-lib/utilities": "^1.7.1"
       },
       "devDependencies": {
         "@remix-run/react": "^2.14.0",
@@ -18517,7 +18517,7 @@
     },
     "packages/seeder": {
       "name": "@rym-lib/seeder",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@prisma/client": "^5.22.0",
@@ -18707,7 +18707,7 @@
     },
     "packages/ui": {
       "name": "@rym-lib/ui",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",
@@ -18918,7 +18918,7 @@
     },
     "packages/uri": {
       "name": "@rym-lib/uri",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",
@@ -19108,7 +19108,7 @@
     },
     "packages/utilities": {
       "name": "@rym-lib/utilities",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
         "@rym-lib/dev-config": "*",

--- a/packages/exception/CHANGELOG.md
+++ b/packages/exception/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/exception
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/exception/package.json
+++ b/packages/exception/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/exception",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",

--- a/packages/inversify-bundler-express/CHANGELOG.md
+++ b/packages/inversify-bundler-express/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/inversify-bundler-express
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/inversify-bundler@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/inversify-bundler-express/package.json
+++ b/packages/inversify-bundler-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/inversify-bundler-express",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/inversify-bundler": "1.7.0",
+    "@rym-lib/inversify-bundler": "1.7.1",
     "@types/express": "^5.0.0",
     "@types/node": "^22.9.0",
     "express": "^4.21.1",
@@ -42,7 +42,7 @@
     "vitest": "^2.1.5"
   },
   "peerDependencies": {
-    "@rym-lib/inversify-bundler": ">=1.7.0",
+    "@rym-lib/inversify-bundler": ">=1.7.1",
     "express": ">=4.0.0"
   }
 }

--- a/packages/inversify-bundler/CHANGELOG.md
+++ b/packages/inversify-bundler/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/inversify-bundler
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/inversify-bundler/package.json
+++ b/packages/inversify-bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/inversify-bundler",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/nakadachi-adapter-react-router/CHANGELOG.md
+++ b/packages/nakadachi-adapter-react-router/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/nakadachi-adapter-react-router
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/nakadachi@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/nakadachi-adapter-react-router/package.json
+++ b/packages/nakadachi-adapter-react-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/nakadachi-adapter-react-router",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/nakadachi": ">=1.7.0",
+    "@rym-lib/nakadachi": ">=1.7.1",
     "@types/node": "^22.4.1",
     "@types/qs": "^6.9.15",
     "npm-check-updates": "^17.0.6",
@@ -55,6 +55,6 @@
   },
   "peerDependencies": {
     "react-router": "^7.8.0",
-    "@rym-lib/nakadachi": ">=1.7.0"
+    "@rym-lib/nakadachi": ">=1.7.1"
   }
 }

--- a/packages/nakadachi-adapter-remix/CHANGELOG.md
+++ b/packages/nakadachi-adapter-remix/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/nakadachi-adapter-remix
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/nakadachi@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/nakadachi-adapter-remix/package.json
+++ b/packages/nakadachi-adapter-remix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/nakadachi-adapter-remix",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@remix-run/node": "^2.11.2",
     "@rym-lib/dev-config": "*",
-    "@rym-lib/nakadachi": ">=1.7.0",
+    "@rym-lib/nakadachi": ">=1.7.1",
     "@types/node": "^22.4.1",
     "@types/qs": "^6.9.15",
     "npm-check-updates": "^17.0.6",
@@ -55,6 +55,6 @@
   },
   "peerDependencies": {
     "@remix-run/node": "^2.11",
-    "@rym-lib/nakadachi": ">=1.7.0"
+    "@rym-lib/nakadachi": ">=1.7.1"
   }
 }

--- a/packages/nakadachi-interactor-mixin-validator/CHANGELOG.md
+++ b/packages/nakadachi-interactor-mixin-validator/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rym-lib/nakadachi-interactor-mixin-validator
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/exception@1.7.1
+  - @rym-lib/inversify-bundler@1.7.1
+  - @rym-lib/nakadachi@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/nakadachi-interactor-mixin-validator/package.json
+++ b/packages/nakadachi-interactor-mixin-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/nakadachi-interactor-mixin-validator",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -36,9 +36,9 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/exception": "1.7.0",
-    "@rym-lib/inversify-bundler": ">=1.7.0",
-    "@rym-lib/nakadachi": ">=1.7.0",
+    "@rym-lib/exception": "1.7.1",
+    "@rym-lib/inversify-bundler": ">=1.7.1",
+    "@rym-lib/nakadachi": ">=1.7.1",
     "@types/node": "^22.9.0",
     "npm-check-updates": "^17.0.6",
     "tsup": "^8.2.4",
@@ -47,8 +47,8 @@
   },
   "peerDependencies": {
     "zod": ">=3.0.0",
-    "@rym-lib/exception": "1.7.0",
-    "@rym-lib/inversify-bundler": ">=1.7.0",
-    "@rym-lib/nakadachi": ">=1.7.0"
+    "@rym-lib/exception": "1.7.1",
+    "@rym-lib/inversify-bundler": ">=1.7.1",
+    "@rym-lib/nakadachi": ">=1.7.1"
   }
 }

--- a/packages/nakadachi-interactor/CHANGELOG.md
+++ b/packages/nakadachi-interactor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rym-lib/nakadachi-interactor
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/exception@1.7.1
+  - @rym-lib/inversify-bundler@1.7.1
+  - @rym-lib/nakadachi@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/nakadachi-interactor/package.json
+++ b/packages/nakadachi-interactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/nakadachi-interactor",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -40,8 +40,8 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/inversify-bundler": ">=1.7.0",
-    "@rym-lib/nakadachi": ">=1.7.0",
+    "@rym-lib/inversify-bundler": ">=1.7.1",
+    "@rym-lib/nakadachi": ">=1.7.1",
     "@types/node": "^22.9.0",
     "npm-check-updates": "^17.0.6",
     "reflect-metadata": "^0.2.2",
@@ -49,8 +49,8 @@
     "vitest": "^2.0.5"
   },
   "peerDependencies": {
-    "@rym-lib/inversify-bundler": ">=1.7.0",
-    "@rym-lib/nakadachi": ">=1.7.0",
-    "@rym-lib/exception": ">=1.7.0"
+    "@rym-lib/inversify-bundler": ">=1.7.1",
+    "@rym-lib/nakadachi": ">=1.7.1",
+    "@rym-lib/exception": ">=1.7.1"
   }
 }

--- a/packages/nakadachi/CHANGELOG.md
+++ b/packages/nakadachi/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/nakadachi
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/nakadachi/package.json
+++ b/packages/nakadachi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/nakadachi",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/query-module-driver-prisma/CHANGELOG.md
+++ b/packages/query-module-driver-prisma/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/query-module-driver-prisma
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/query-module-sql-builder@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/query-module-driver-prisma/package.json
+++ b/packages/query-module-driver-prisma/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/query-module-driver-prisma",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -36,12 +36,12 @@
     "ncu": "npm-check-updates"
   },
   "dependencies": {
-    "@rym-lib/query-module-sql-builder": "1.7.0"
+    "@rym-lib/query-module-sql-builder": "1.7.1"
   },
   "devDependencies": {
     "@prisma/client": "^5.22.0",
     "@rym-lib/dev-config": "*",
-    "@rym-lib/query-module": "1.7.0",
+    "@rym-lib/query-module": "1.7.1",
     "@types/node": "^22.4.1",
     "@vitest/coverage-v8": "^3.2.4",
     "npm-check-updates": "^17.0.6",

--- a/packages/query-module-driver-sequelize/CHANGELOG.md
+++ b/packages/query-module-driver-sequelize/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/query-module-driver-sequelize
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/query-module-sql-builder@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/query-module-driver-sequelize/package.json
+++ b/packages/query-module-driver-sequelize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/query-module-driver-sequelize",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -26,11 +26,11 @@
     "ncu": "npm-check-updates"
   },
   "dependencies": {
-    "@rym-lib/query-module-sql-builder": "1.7.0"
+    "@rym-lib/query-module-sql-builder": "1.7.1"
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/query-module": "1.7.0",
+    "@rym-lib/query-module": "1.7.1",
     "@types/node": "^22.4.1",
     "@vitest/coverage-v8": "^3.2.4",
     "npm-check-updates": "^17.0.6",

--- a/packages/query-module-pagination/CHANGELOG.md
+++ b/packages/query-module-pagination/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/query-module-pagination
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/query-module-pagination/package.json
+++ b/packages/query-module-pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/query-module-pagination",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/query-module": "1.7.0",
+    "@rym-lib/query-module": "1.7.1",
     "@types/node": "^22.4.1",
     "npm-check-updates": "^17.0.6",
     "tsup": "^8.2.4",

--- a/packages/query-module-sql-builder/CHANGELOG.md
+++ b/packages/query-module-sql-builder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/query-module-sql-builder
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/query-module-sql-builder/package.json
+++ b/packages/query-module-sql-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/query-module-sql-builder",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/query-module": "^1.7.0",
+    "@rym-lib/query-module": "^1.7.1",
     "@types/node": "^22.15.17",
     "@vitest/coverage-v8": "^3.1.3",
     "tsup": "^8.2.4",

--- a/packages/query-module/CHANGELOG.md
+++ b/packages/query-module/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/query-module
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/exception@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/query-module/package.json
+++ b/packages/query-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/query-module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@rym-lib/dev-config": "*",
-    "@rym-lib/utilities": "1.7.0",
+    "@rym-lib/utilities": "1.7.1",
     "@types/node": "^22.4.1",
     "@vitest/coverage-v8": "^3.0.3",
     "npm-check-updates": "^17.0.6",
@@ -73,6 +73,6 @@
     "vitest": "^3.0.3"
   },
   "dependencies": {
-    "@rym-lib/exception": "^1.7.0"
+    "@rym-lib/exception": "^1.7.1"
   }
 }

--- a/packages/rdb-command/CHANGELOG.md
+++ b/packages/rdb-command/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/rdb-command
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/rdb-command/package.json
+++ b/packages/rdb-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/rdb-command",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",

--- a/packages/remix-helper/CHANGELOG.md
+++ b/packages/remix-helper/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rym-lib/remix-helper
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+- Updated dependencies
+  - @rym-lib/utilities@1.7.1
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/remix-helper/package.json
+++ b/packages/remix-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rym-lib/remix-helper",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",
@@ -39,7 +39,7 @@
     "ncu": "npm-check-updates"
   },
   "dependencies": {
-    "@rym-lib/utilities": "^1.7.0"
+    "@rym-lib/utilities": "^1.7.1"
   },
   "devDependencies": {
     "@remix-run/react": "^2.14.0",

--- a/packages/seeder/CHANGELOG.md
+++ b/packages/seeder/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/nakadachi-interactor-mixin-validator
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/seeder/package.json
+++ b/packages/seeder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rym-lib/seeder",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",

--- a/packages/seeder/src/seeder.spec.ts
+++ b/packages/seeder/src/seeder.spec.ts
@@ -25,12 +25,7 @@ describe('Seeder', () => {
         })
 
         it('結果: bigintの主キー値でINSERT文を実行する', async () => {
-          await seeder.load(
-            'users',
-            'id',
-            ['id', 'name'],
-            [[10n, 'test']],
-          )
+          await seeder.load('users', 'id', ['id', 'name'], [[10n, 'test']])
 
           expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
             'INSERT INTO `users` (`id`, `name`) VALUES ($1, $2)',
@@ -48,12 +43,7 @@ describe('Seeder', () => {
         })
 
         it('結果: bigintの主キー値でUPDATE文を実行する', async () => {
-          await seeder.load(
-            'users',
-            'id',
-            ['id', 'name'],
-            [[10n, 'new_name']],
-          )
+          await seeder.load('users', 'id', ['id', 'name'], [[10n, 'new_name']])
 
           expect(mockPrismaClient.$executeRawUnsafe).toHaveBeenCalledWith(
             'UPDATE `users` SET `name` = $1 WHERE `id` = $2',
@@ -71,12 +61,7 @@ describe('Seeder', () => {
         })
 
         it('結果: UPDATE・INSERTともに実行しない', async () => {
-          await seeder.load(
-            'users',
-            'id',
-            ['id', 'name'],
-            [[10n, 'test']],
-          )
+          await seeder.load('users', 'id', ['id', 'name'], [[10n, 'test']])
 
           expect(mockPrismaClient.$executeRawUnsafe).not.toHaveBeenCalled()
         })

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/ui
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rym-lib/ui",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/uri/CHANGELOG.md
+++ b/packages/uri/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/uri
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/uri/package.json
+++ b/packages/uri/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rym-lib/uri",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",

--- a/packages/utilities/CHANGELOG.md
+++ b/packages/utilities/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rym-lib/utilities
 
+## 1.7.1
+
+### Patch Changes
+
+- fix(seeder): bigint型の主キー・カラムに対応
+
 ## 1.7.0
 
 ### Minor Changes

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rym-lib/utilities",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": false,
   "author": {
     "name": "mizuki_r",


### PR DESCRIPTION
## Summary
- changeset により全パッケージを 1.7.1 に patch bump
- 内容: fix(seeder): bigint型の主キー・カラムに対応 (#83)

マージ後に GitHub Release `v1.7.1` を作成して npm publish をトリガーする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

changeset により全パッケージを 1.7.0 → 1.7.1 にパッチバンプするリリース PR です。実装上の変更は PR #83 で完了しており、本 PR にはソースの修正は含まれません。

- **バージョン更新**: 全 18 パッケージの `package.json` と `CHANGELOG.md` を 1.7.1 に統一。
- **テスト整形**: `packages/seeder/src/seeder.spec.ts` の bigint テストケースで、複数行の関数呼び出しを Prettier のルール（単一行）に合わせて整形。
- **ロックファイル更新**: `package-lock.json` が各パッケージバンプに対応して自動更新されている。

<h3>Confidence Score: 5/5</h3>

changeset による標準的なバンプPRであり、ソース変更は `seeder.spec.ts` のPrettier整形のみ。マージしても問題ありません。

全パッケージのバンプとCHANGELOG更新のみで、実装変更はなし。`seeder.spec.ts` の修正は純粋なフォーマット整形（複数行引数→単行）で動作に影響しない。各パッケージの依存バージョン整合性も問題ない。

特に注意が必要なファイルはありません。

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/seeder/src/seeder.spec.ts | bigint主キーのテストケースにおける関数呼び出しのフォーマットを複数行→単一行に変更（Prettier準拠） |
| packages/seeder/package.json | バージョンを 1.7.0 → 1.7.1 にパッチバンプ（changeset によるリリース） |
| packages/seeder/CHANGELOG.md | 1.7.1 のパッチリリースエントリを追加（fix(seeder): bigint型の主キー・カラムに対応） |
| packages/inversify-bundler-express/package.json | 1.7.0 → 1.7.1 バンプ、依存パッケージ @rym-lib/inversify-bundler も同様に更新 |
| package-lock.json | 全パッケージの 1.7.1 バンプに伴うロックファイルの自動更新 |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["seeder.load() 呼び出し"] --> B["$queryRawUnsafe で既存行を SELECT"]
    B --> C{行が存在するか?}
    C -- なし --> D["INSERT 文を実行"]
    C -- あり --> E["isEqualValue() で全カラムを比較"]
    E --> F{全カラム同値?}
    F -- 同値 --> G["スキップ (no-op)"]
    F -- 差分あり --> H["UPDATE 文を実行"]

    subgraph isEqualValue["isEqualValue ロジック (PR #83 の修正箇所)"]
        I{"一方が bigint?"}
        I -- Yes --> J{"両方が isNumericConvertible?"}
        J -- Yes --> K["BigInt(a) === BigInt(b) で比較"]
        J -- No --> L["=== で比較"]
        I -- No --> M{"両方が Date?"}
        M -- Yes --> N["getTime() で比較"]
        M -- No --> O["=== で比較"]
    end

    E --> I
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["seeder.load() 呼び出し"] --> B["$queryRawUnsafe で既存行を SELECT"]
    B --> C{行が存在するか?}
    C -- なし --> D["INSERT 文を実行"]
    C -- あり --> E["isEqualValue() で全カラムを比較"]
    E --> F{全カラム同値?}
    F -- 同値 --> G["スキップ (no-op)"]
    F -- 差分あり --> H["UPDATE 文を実行"]

    subgraph isEqualValue["isEqualValue ロジック (PR #83 の修正箇所)"]
        I{"一方が bigint?"}
        I -- Yes --> J{"両方が isNumericConvertible?"}
        J -- Yes --> K["BigInt(a) === BigInt(b) で比較"]
        J -- No --> L["=== で比較"]
        I -- No --> M{"両方が Date?"}
        M -- Yes --> N["getTime() で比較"]
        M -- No --> O["=== で比較"]
    end

    E --> I
```

</a>

<sub>Reviews (1): Last reviewed commit: ["v1.7.1"](https://github.com/rymizuki/rym-lib/commit/8c2f5ae9e66718ee5ecaae01def9de6073347cfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41857108)</sub>

<!-- /greptile_comment -->